### PR TITLE
Initial support for PoseAssets

### DIFF
--- a/FortnitePorting/Export/ExportTypes.cs
+++ b/FortnitePorting/Export/ExportTypes.cs
@@ -40,20 +40,26 @@ public class ExportHeadMeta : ExportPartMeta
     public readonly Dictionary<ECustomHatType, string> MorphNames = new();
     public FLinearColor SkinColor;
     public List<PoseData> PoseData = [];
+    public List<ReferencePose> ReferencePose = [];
+    public bool CopyPoseData = false;
 }
+
+public record ReferencePose(string BoneName, FVector Location, FQuat Rotation, FVector Scale);
 
 public class PoseData
 {
     public string Name;
     public List<PoseKey> Keys = new List<PoseKey>();
+    public readonly float[] CurveData;
 
-    public PoseData(string name)
+    public PoseData(string name, float[] curveData)
     {
         Name = name;
+        CurveData = curveData;
     }
 }
 
-public record PoseKey(string Name, FVector Location, FQuat Rotation, FVector Scale);
+public record PoseKey(string Name, FVector Location, FQuat Rotation, FVector Scale, int PoseIndex, int BoneTransformIndex);
 
 public class ExportAttachMeta : ExportPartMeta
 {

--- a/FortnitePorting/Export/ExportTypes.cs
+++ b/FortnitePorting/Export/ExportTypes.cs
@@ -33,15 +33,14 @@ public record ExportPart : ExportMesh
 
 public class ExportPartMeta
 {
+    public List<PoseData> PoseData = [];
+    public List<ReferencePose> ReferencePose = [];
 }
 
 public class ExportHeadMeta : ExportPartMeta
 {
     public readonly Dictionary<ECustomHatType, string> MorphNames = new();
     public FLinearColor SkinColor;
-    public List<PoseData> PoseData = [];
-    public List<ReferencePose> ReferencePose = [];
-    public bool CopyPoseData = false;
 }
 
 public record ReferencePose(string BoneName, FVector Location, FQuat Rotation, FVector Scale);

--- a/FortnitePorting/Export/ExportTypes.cs
+++ b/FortnitePorting/Export/ExportTypes.cs
@@ -152,9 +152,18 @@ public class ExportAnimSection
     public float Length;
     public float LinkValue;
     public bool Loop;
+    public List<ExportCurve> Curves = [];
 
     [JsonIgnore] public UAnimSequence AssetRef;
 }
+
+public class ExportCurve
+{
+    public string Name;
+    public List<ExportCurveKey> Keys;
+}
+
+public record ExportCurveKey(float Time, float Value);
 
 public class ExportSound
 {

--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -161,18 +161,6 @@ public class ExporterInstance
         if (part.TryGetValue(out UObject additionalData, "AdditionalData"))
             switch (additionalData.ExportType)
             {
-                case "CustomCharacterFaceData":
-                {
-                    // Massive assumption that this part is associated with FaceAcc and FaceAcc
-                    // occasionally needs the pose data copied to accomodate for on-face items.
-                    // In the future, this should probably be selectively enabled.
-                    var meta = new ExportHeadMeta();
-                    if (additionalData.TryGetValue(out UAnimBlueprintGeneratedClass animBlueprint, "AnimClass"))
-                        meta.CopyPoseData = true;
-
-                    exportPart.Meta = meta;
-                    break;
-                }
                 case "CustomCharacterHeadData":
                 {
                     var meta = new ExportHeadMeta();

--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -118,9 +118,9 @@ public class ExporterInstance
             }
         }
 
-        USkeleton? skeleton = poseAsset.Skeleton.Load<USkeleton>();
-        if (skeleton == null)
-            return;
+        if (poseAsset.RetargetSourceAssetReferencePose is null) return;
+        if (poseAsset.Skeleton is null) return;
+        if (!poseAsset.Skeleton.TryLoad<USkeleton>(out var skeleton)) return;
 
         Dictionary<string, int> referenceMap = skeleton.ReferenceSkeleton.FinalNameToIndexMap.ToDictionary(k => k.Key.ToLower(), k => k.Value);
         foreach (FName boneName in poseContainer.Tracks)
@@ -192,7 +192,14 @@ public class ExporterInstance
                     {
                         var animBlueprintData = animBlueprint.ClassDefaultObject.Load()!;
                         if (animBlueprintData.TryGetValue(out FStructFallback poseAssetNode, "AnimGraphNode_PoseBlendNode"))
+                        {
                             ParsePoseAsset(poseAssetNode.Get<UPoseAsset>("PoseAsset"), meta);
+                        }
+                        else if (skeletalMesh.ReferenceSkeleton.FinalRefBoneInfo.Any(bone => bone.Name.Text.Equals("FACIAL_C_FacialRoot", StringComparison.OrdinalIgnoreCase))
+                                 && CUE4ParseVM.Provider.TryLoadObject("FortniteGame/Content/Characters/Player/Male/Medium/Heads/M_MED_Jonesy3L_Head/Meshes/3L/3L_lod2_Facial_Poses_PoseAsset", out UPoseAsset poseAsset))
+                        {
+                            ParsePoseAsset(poseAsset, meta);
+                        }
                     }
 
                     exportPart.Meta = meta;

--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -122,11 +122,11 @@ public class ExporterInstance
         if (poseAsset.Skeleton is null) return;
         if (!poseAsset.Skeleton.TryLoad<USkeleton>(out var skeleton)) return;
 
-        var referenceMap = skeleton.ReferenceSkeleton.FinalNameToIndexMap.ToDictionary(k => k.Key.ToLower(), k => k.Value);
+        var referenceMap = new Dictionary<string, int>(skeleton.ReferenceSkeleton.FinalNameToIndexMap, StringComparer.OrdinalIgnoreCase);
         foreach (var boneName in poseContainer.Tracks)
         {
             var boneNameStr = boneName.PlainText;
-            if (!referenceMap.TryGetValue(boneNameStr.ToLower(), out var idx))
+            if (!referenceMap.TryGetValue(boneNameStr, out var idx))
             {
                 Log.Warning($"{poseAsset.Name}: {boneNameStr} missing from referenceSkeleton ({skeleton.Name})");
                 continue;

--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -104,6 +104,9 @@ public class ExporterInstance
             {
                 var pose = meta.PoseData[influence.PoseIndex];
                 var transform = poses[influence.PoseIndex].LocalSpacePose[influence.BoneTransformIndex];
+                if (!transform.Rotation.IsNormalized)
+                    transform.Rotation.Normalize();
+
                 pose.Keys.Add(new PoseKey(
                     poseTrackName.PlainText, /* Bone name to move */
                     transform.Translation,

--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -60,24 +60,24 @@ public class ExporterInstance
             return;
         }
 
-        FPoseDataContainer poseContainer = poseAsset.PoseContainer;
-        FPoseData[] poses = poseContainer.Poses;
+        var poseContainer = poseAsset.PoseContainer;
+        var poses = poseContainer.Poses;
         if (poses.Length == 0)
         {
             Log.Warning($"{poseAsset.Name}: has no poses");
             return;
         }
 
-        FName[]? poseNames = poseContainer.PoseFNames;
-        if (poseNames == null || poseNames.Length == 0)
+        var poseNames = poseContainer.PoseFNames;
+        if (poseNames is null || poseNames.Length == 0)
         {
             Log.Warning($"{poseAsset.Name}: PoseFNames is null or empty");
             return;
         }
 
         /* Assert number of tracks == number of bones for given skeleton */
-        FName[] poseTracks = poseContainer.Tracks;
-        FPoseAssetInfluences[] poseTrackInfluences = poseContainer.TrackPoseInfluenceIndices;
+        var poseTracks = poseContainer.Tracks;
+        var poseTrackInfluences = poseContainer.TrackPoseInfluenceIndices;
         if (poseTracks.Length != poseTrackInfluences.Length)
         {
             Log.Warning($"{poseAsset.Name}: length of Tracks != length of TrackPoseInfluenceIndices");
@@ -85,28 +85,28 @@ public class ExporterInstance
         }
 
         /* Add poses by name first in order they appear */
-        for (int i = 0; i < poses.Length; i++)
+        for (var i = 0; i < poses.Length; i++)
         {
-            FPoseData pose = poses[i];
-            FName poseName = poseNames[i];
+            var pose = poses[i];
+            var poseName = poseNames[i];
 
             if (pose.CurveData.Length != 0 && pose.CurveData.Length != poses.Length - 1)
                 Log.Warning($"{poseAsset.Name}: {poseName} length of CurveData != length of poses");
-            PoseData poseData = new PoseData(poseName.PlainText, pose.CurveData);
+            var poseData = new PoseData(poseName.PlainText, pose.CurveData);
             meta.PoseData.Add(poseData);
         }
 
         /* Discover connection between bone name and relative location. */
-        for (int i = 0; i < poseTrackInfluences.Length; i++)
+        for (var i = 0; i < poseTrackInfluences.Length; i++)
         {
-            FPoseAssetInfluences poseTrackInfluence = poseTrackInfluences[i];
-            if (poseTrackInfluence == null) continue;
+            var poseTrackInfluence = poseTrackInfluences[i];
+            if (poseTrackInfluence is null) continue;
 
-            FName poseTrackName = poseTracks[i];
+            var poseTrackName = poseTracks[i];
             foreach (var influence in poseTrackInfluence.Influences)
             {
-                PoseData pose = meta.PoseData[influence.PoseIndex];
-                FTransform transform = poses[influence.PoseIndex].LocalSpacePose[influence.BoneTransformIndex];
+                var pose = meta.PoseData[influence.PoseIndex];
+                var transform = poses[influence.PoseIndex].LocalSpacePose[influence.BoneTransformIndex];
                 pose.Keys.Add(new PoseKey(
                     poseTrackName.PlainText, /* Bone name to move */
                     transform.Translation,
@@ -122,11 +122,11 @@ public class ExporterInstance
         if (poseAsset.Skeleton is null) return;
         if (!poseAsset.Skeleton.TryLoad<USkeleton>(out var skeleton)) return;
 
-        Dictionary<string, int> referenceMap = skeleton.ReferenceSkeleton.FinalNameToIndexMap.ToDictionary(k => k.Key.ToLower(), k => k.Value);
-        foreach (FName boneName in poseContainer.Tracks)
+        var referenceMap = skeleton.ReferenceSkeleton.FinalNameToIndexMap.ToDictionary(k => k.Key.ToLower(), k => k.Value);
+        foreach (var boneName in poseContainer.Tracks)
         {
             var boneNameStr = boneName.PlainText;
-            if (!referenceMap.TryGetValue(boneNameStr.ToLower(), out int idx))
+            if (!referenceMap.TryGetValue(boneNameStr.ToLower(), out var idx))
             {
                 Log.Warning($"{poseAsset.Name}: {boneNameStr} missing from referenceSkeleton ({skeleton.Name})");
                 continue;
@@ -138,7 +138,7 @@ public class ExporterInstance
                 continue;
             }
 
-            FTransform transform = poseAsset.RetargetSourceAssetReferencePose[idx];
+            var transform = poseAsset.RetargetSourceAssetReferencePose[idx];
             meta.ReferencePose.Add(new ReferencePose(boneNameStr, transform.Translation, transform.Rotation, transform.Scale3D));
         }
     }

--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -89,9 +89,6 @@ public class ExporterInstance
         {
             var pose = poses[i];
             var poseName = poseNames[i];
-
-            if (pose.CurveData.Length != 0 && pose.CurveData.Length != poses.Length - 1)
-                Log.Warning($"{poseAsset.Name}: {poseName} length of CurveData != length of poses");
             var poseData = new PoseData(poseName.PlainText, pose.CurveData);
             meta.PoseData.Add(poseData);
         }

--- a/FortnitePorting/Export/Types/AnimExportData.cs
+++ b/FortnitePorting/Export/Types/AnimExportData.cs
@@ -83,6 +83,18 @@ public class AnimExportData : ExportDataBase
             anim.LinkValue = currentSection.LinkValue;
             anim.Loop = currentSection.SectionName == currentSection.NextSectionName || currentSection.NextSectionName.IsNone;
             anim.AssetRef = sequence;
+            
+            // todo this is alr serialize in ueanim, figure out better way to access that rather than serializing in export response
+            var floatCurves = sequence.CompressedCurveData.FloatCurves ?? [];
+            foreach (var curve in floatCurves)
+            {
+                anim.Curves.Add(new ExportCurve
+                {
+                    Name = curve.Name.DisplayName.Text,
+                    Keys = curve.FloatCurve.Keys.Select(x => new ExportCurveKey(x.Time, x.Value)).ToList()
+                });
+            }
+            
             sections.Add(anim);
         
             if (anim.Loop) return;

--- a/FortnitePorting/Export/Types/AnimExportData.cs
+++ b/FortnitePorting/Export/Types/AnimExportData.cs
@@ -90,7 +90,7 @@ public class AnimExportData : ExportDataBase
             {
                 anim.Curves.Add(new ExportCurve
                 {
-                    Name = curve.Name.DisplayName.Text,
+                    Name = curve.CurveName.Text,
                     Keys = curve.FloatCurve.Keys.Select(x => new ExportCurveKey(x.Time, x.Value)).ToList()
                 });
             }

--- a/FortnitePorting/Export/Types/MeshExportData.cs
+++ b/FortnitePorting/Export/Types/MeshExportData.cs
@@ -26,10 +26,10 @@ namespace FortnitePorting.Export.Types;
 
 public class MeshExportData : ExportDataBase
 {
-    public readonly List<ExportMesh> Meshes = new();
-    public readonly List<ExportMesh> OverrideMeshes = new();
-    public readonly List<ExportOverrideMaterial> OverrideMaterials = new();
-    public readonly List<ExportOverrideParameters> OverrideParameters = new();
+    public readonly List<ExportMesh> Meshes = [];
+    public readonly List<ExportMesh> OverrideMeshes = [];
+    public readonly List<ExportOverrideMaterial> OverrideMaterials = [];
+    public readonly List<ExportOverrideParameters> OverrideParameters = [];
     public readonly AnimExportData Animation;
 
     public MeshExportData(string name, UObject asset, FStructFallback[] styles, EAssetType type, EExportTargetType exportType) : base(name, asset, styles, type, EExportType.Mesh, exportType)
@@ -53,7 +53,7 @@ public class MeshExportData : ExportDataBase
                 }
 
                 ExportHeadMeta? partWithPoseData = null;
-                List<ExportHeadMeta> exportPartsToCopyTo = new List<ExportHeadMeta>();
+                var exportPartsToCopyTo = new List<ExportHeadMeta>();
                 AssetsVM.ExportChunks = parts.Length;
                 foreach (var part in parts)
                 {
@@ -63,15 +63,16 @@ public class MeshExportData : ExportDataBase
                     }
 
                     var resolvedPart = Exporter.CharacterPart(part);
-                    if (resolvedPart?.Meta is ExportHeadMeta)
+                    if (resolvedPart?.Meta is ExportHeadMeta headMeta)
                     {
-                        var headMeta = (ExportHeadMeta)resolvedPart.Meta;
                         if (headMeta.PoseData.Count != 0)
                         {
                             if (partWithPoseData != null)
                                 Log.Warning("multiple character parts contained PoseData, results may be inaccurate");
                             partWithPoseData = headMeta;
-                        } else if (headMeta.CopyPoseData == true) {
+                        } 
+                        else if (headMeta.CopyPoseData) 
+                        {
                             exportPartsToCopyTo.AddIfNotNull(headMeta);
                         }
                     }
@@ -80,8 +81,9 @@ public class MeshExportData : ExportDataBase
                 }
 
                 // Copy data around
-                if (partWithPoseData != null) {
-                    foreach (ExportHeadMeta part in exportPartsToCopyTo)
+                if (partWithPoseData is not null) 
+                {
+                    foreach (var part in exportPartsToCopyTo)
                     {
                         part.PoseData = partWithPoseData.PoseData;
                         part.ReferencePose = partWithPoseData.ReferencePose;

--- a/FortnitePorting/Export/Types/MeshExportData.cs
+++ b/FortnitePorting/Export/Types/MeshExportData.cs
@@ -52,8 +52,8 @@ public class MeshExportData : ExportDataBase
                     }
                 }
 
-                ExportHeadMeta? partWithPoseData = null;
-                var exportPartsToCopyTo = new List<ExportHeadMeta>();
+                ExportPartMeta? partWithPoseData = null;
+                var exportPartsToCopyTo = new List<ExportPartMeta>();
                 AssetsVM.ExportChunks = parts.Length;
                 foreach (var part in parts)
                 {
@@ -63,17 +63,18 @@ public class MeshExportData : ExportDataBase
                     }
 
                     var resolvedPart = Exporter.CharacterPart(part);
-                    if (resolvedPart?.Meta is ExportHeadMeta headMeta)
+                    var meta = resolvedPart?.Meta;
+                    if (meta is not null)
                     {
-                        if (headMeta.PoseData.Count != 0)
+                        if (meta.PoseData.Count != 0)
                         {
                             if (partWithPoseData != null)
                                 Log.Warning("multiple character parts contained PoseData, results may be inaccurate");
-                            partWithPoseData = headMeta;
-                        } 
-                        else if (headMeta.CopyPoseData) 
+                            partWithPoseData = meta;
+                        }
+                        else
                         {
-                            exportPartsToCopyTo.AddIfNotNull(headMeta);
+                            exportPartsToCopyTo.Add(meta);
                         }
                     }
                     Meshes.AddIfNotNull(resolvedPart);

--- a/FortnitePorting/Globals.cs
+++ b/FortnitePorting/Globals.cs
@@ -8,7 +8,7 @@ namespace FortnitePorting;
 
 public static class Globals
 {
-    public static readonly FPVersion Version = new(2, 0, 8);
+    public static readonly FPVersion Version = new(2, 0, 11);
     public static readonly string VersionString = Version.ToString();
 
     public const string DISCORD_URL = "https://discord.gg/DZ5YFXdBA6";

--- a/FortnitePorting/Plugins/Blender/__init__.py
+++ b/FortnitePorting/Plugins/Blender/__init__.py
@@ -11,7 +11,7 @@ bl_info = {
     "description": "Fortnite Porting Blender Plugin",
     "author": "Half",
     "blender": (4, 0, 0),
-    "version": (2, 0, 8),
+    "version": (2, 0, 11),
     "category": "Import",
 }
 

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -591,7 +591,7 @@ class DataImportTask:
             case "Body":
                 meta = get_meta(["SkinColor"])
             case "Head":
-                meta = get_meta(["MorphNames", "HatType", "PoseData", "ReferencePose"])
+                meta = get_meta(["MorphNames", "HatType"])
                 shape_keys = imported_mesh.data.shape_keys
                 if (morph_name := meta.get("MorphNames").get(meta.get("HatType"))) and shape_keys is not None:
                     for key in shape_keys.key_blocks:

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -605,19 +605,8 @@ class DataImportTask:
                     try:
                         bpy.ops.object.mode_set(mode='OBJECT')
 
-                        # Find the ARMATURE modifier
-                        armature_modifiers = [mod for mod in imported_mesh.modifiers if mod.type == "ARMATURE"]
-                        assert len(armature_modifiers) == 1, "expected at least one armature modifier"
-                        armature_modifier: bpy.types.ArmatureModifier = armature_modifiers[0]
-
-                        # Find the ARMATURE
-                        armatures = [
-                            ob
-                            for ob in bpy.data.objects
-                            if ob.type == "ARMATURE" and imported_mesh.name in ob.name
-                        ]
-                        assert len(armatures) == 1, "expected at least one armature"
-                        armature: bpy.types.Object = armatures[0]
+                        armature: bpy.types.Object = imported_object
+                        armature_modifier: bpy.types.ArmatureModifier = first(imported_mesh.modifiers, lambda mod: mod.type == "ARMATURE")
 
                         # Grab reference pose data
                         reference_pose = meta.get("ReferencePose", dict())

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -443,7 +443,7 @@ class DataImportTask:
             mesh_track = active_mesh.data.shape_keys.animation_data.nla_tracks.new(prev=None)
             mesh_track.name = "Sections"
 
-        def import_sections(sections, skeleton, track):
+        def import_sections(sections, skeleton, track, is_main_skeleton = False):
             total_frames = 0
             for section in sections:
                 path = section.get("Path")
@@ -459,7 +459,7 @@ class DataImportTask:
                 strip = track.strips.new(section_name, time_to_frame(time_offset), anim)
                 strip.repeat = loop_count
                 
-                if (curves := section.get("Curves")) and len(curves) > 0 and active_mesh.data.shape_keys is not None:
+                if (curves := section.get("Curves")) and len(curves) > 0 and active_mesh.data.shape_keys is not None and is_main_skeleton:
                     key_blocks = active_mesh.data.shape_keys.key_blocks
                     for key_block in key_blocks:
                         key_block.value = 0
@@ -478,7 +478,7 @@ class DataImportTask:
                     
             return total_frames
         
-        total_frames = import_sections(data.get("Sections"), target_skeleton, target_track)
+        total_frames = import_sections(data.get("Sections"), target_skeleton, target_track, True)
         if self.options.get("UpdateTimelineLength"):
             bpy.context.scene.frame_end = total_frames
          

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -683,11 +683,7 @@ class DataImportTask:
                                 post_quat = Quaternion(post_quat) if (post_quat := edit_bone.get("post_quat")) else Quaternion()
 
                                 q = post_quat.copy()
-                                if edit_bone.parent is None:
-                                    q.rotate(make_quat(rotation).conjugated())
-                                else:
-                                    q.rotate(make_quat(rotation))
-
+                                q.rotate(make_quat(rotation))
                                 quat = post_quat.copy()
                                 quat.rotate(q.conjugated())
                                 pose_bone.rotation_quaternion = quat.conjugated() @ pose_bone.rotation_quaternion

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -601,11 +601,10 @@ class DataImportTask:
                             key.value = 1.0
 
                 if (pose_data := meta.get("PoseData")):
+                    armature: bpy.types.Object = imported_object
                     original_mode = bpy.context.active_object.mode
                     try:
                         bpy.ops.object.mode_set(mode='OBJECT')
-
-                        armature: bpy.types.Object = imported_object
                         armature_modifier: bpy.types.ArmatureModifier = first(imported_mesh.modifiers, lambda mod: mod.type == "ARMATURE")
 
                         # Grab reference pose data
@@ -713,17 +712,16 @@ class DataImportTask:
                             if curve_sum and (curve_sum > 1.0001 or curve_sum < 0.999):
                                 Log.warn(f'{pose_name}: has interesting '
                                          'curve data! Implement this feature...')
-
+                    except Exception as e:
+                        Log.error("Failed to import PoseAsset data from "
+                                  f"{imported_mesh.name}: {e}")
+                    finally:
                         # Final reset before re-entering regular import mode.
                         bpy.context.view_layer.objects.active = armature
                         bpy.ops.object.mode_set(mode='POSE')
                         bpy.ops.pose.select_all(action='SELECT')
                         bpy.ops.pose.transforms_clear()
                         bpy.ops.pose.select_all(action='DESELECT')
-                    except Exception as e:
-                        Log.error("Failed to import PoseAsset data from "
-                                  f"{imported_mesh.name}: {e}")
-                    finally:
                         bpy.ops.object.mode_set(mode=original_mode)
             case _:
                 meta = {}

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -675,7 +675,8 @@ class DataImportTask:
                         pose_bone.matrix_basis.identity()
 
                         rotation = bone.get('Rotation')
-                        assert rotation.get('IsNormalized'), "non-normalized rotation unsupported"
+                        if not rotation.get('IsNormalized'):
+                            Log.warn(f"rotation not normalized for {bone_name} in pose {pose_name}")
 
                         edit_bone = pose_bone.bone
                         post_quat = Quaternion(post_quat) if (post_quat := edit_bone.get("post_quat")) else Quaternion()

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -710,19 +710,6 @@ class DataImportTask:
 
                     # Use name from pose data
                     imported_mesh.data.shape_keys.key_blocks[-1].name = pose_name
-
-                # TODO: FishThicc triggers interesting curve data. Investigate tomorrow...
-                for pose in pose_data:
-                    if not (curve_data := pose.get('CurveData')):
-                        continue
-
-                    # If there's curve data that's more than the
-                    # current pose being 1.0 and all other poses
-                    # non-zero, note that.
-                    curve_sum = sum([abs(x) for x in curve_data])
-                    if curve_sum and (curve_sum > 1.0001 or curve_sum < 0.999):
-                        Log.warn(f'{pose_name}: has interesting '
-                                    'curve data! Implement this feature...')
             except Exception as e:
                 Log.error("Failed to import PoseAsset data from "
                             f"{imported_mesh.name}: {e}")

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -651,16 +651,12 @@ class DataImportTask:
                                     Log.warn(f"empty bone name for pose {pose}")
                                     continue
 
-                                pose_bone: bpy.types.PoseBone = armature.pose.bones.get(bone_name)
-                                if not pose_bone:
-                                    # For some reason, some of the bones start capitalized and some dont
-                                    bone_name = bone_name[0].capitalize() + bone_name[1:]
-                                    pose_bone = armature.pose.bones.get(bone_name)
+                                pose_bone: bpy.types.PoseBone = get_case_insensitive(armature.pose.bones, bone_name)
                                 if not pose_bone:
                                     # For cases where pose data tries to move a non-existent bone
                                     # i.e. Poseidon has no 'Tongue' but its in the pose asset
                                     if is_head:
-                                        # There are likely many missing bones in FaceAcc, but we
+                                        # There are likely many missing bones in non-Head parts, but we
                                         # process as many as we can.
                                         Log.warn(f"could not find: {bone_name} for pose {pose_name}")
                                     continue
@@ -1403,6 +1399,7 @@ def get_case_insensitive(source, string):
     for item in source:
         if item.name.casefold() == string.casefold():
             return item
+    return None
 
 
 def replace_or_add_parameter(list, replace_item):

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -590,137 +590,139 @@ class DataImportTask:
         match mesh_type:
             case "Body":
                 meta = get_meta(["SkinColor"])
-            case "Head" | "Face":
+            case "Head":
                 meta = get_meta(["MorphNames", "HatType", "PoseData", "ReferencePose"])
-                is_head = mesh_type == "Head"
-
                 shape_keys = imported_mesh.data.shape_keys
                 if (morph_name := meta.get("MorphNames").get(meta.get("HatType"))) and shape_keys is not None:
                     for key in shape_keys.key_blocks:
                         if key.name.casefold() == morph_name.casefold():
                             key.value = 1.0
-
-                if (pose_data := meta.get("PoseData")):
-                    armature: bpy.types.Object = imported_object
-                    original_mode = bpy.context.active_object.mode
-                    try:
-                        bpy.ops.object.mode_set(mode='OBJECT')
-                        armature_modifier: bpy.types.ArmatureModifier = first(imported_mesh.modifiers, lambda mod: mod.type == "ARMATURE")
-
-                        # Grab reference pose data
-                        reference_pose = meta.get("ReferencePose", dict())
-
-                        # Check how many bones are scaled in the reference pose
-                        face_attach_scale = Vector((1, 1, 1))
-                        for entry in reference_pose:
-                            scale = make_vector(entry.get('Scale'))
-                            if scale != Vector((1, 1, 1)):
-                                if entry.get('BoneName', '').casefold() == 'faceattach':
-                                    face_attach_scale = scale
-                                Log.warn(f"Non-zero scale: {entry}")
-
-                        if not shape_keys:
-                            # Create Basis shape key
-                            imported_mesh.shape_key_add(name="Basis", from_mix=False)
-
-                        # NOTE: I think faceAttach affects the expected location
-                        # I'm making this assumption from observation of an old
-                        # export of face poses for Polar Patroller.
-                        loc_scale = (0.01 if self.options.get("ScaleDown") else 1)
-                        for pose in pose_data:
-                            # If there are no influences, don't bother
-                            if not (influences := pose.get('Keys')):
-                                continue
-
-                            if not (pose_name := pose.get('Name')):
-                                Log.warn("skipping pose data with no pose name")
-                                continue
-
-                            # Enter pose mode
-                            bpy.context.view_layer.objects.active = armature
-                            bpy.ops.object.mode_set(mode='POSE')
-
-                            # Reset all transforms to default
-                            bpy.ops.pose.select_all(action='SELECT')
-                            bpy.ops.pose.transforms_clear()
-                            bpy.ops.pose.select_all(action='DESELECT')
-
-                            # Move bones accordingly
-                            for bone in influences:
-                                if not (bone_name := bone.get('Name')):
-                                    Log.warn(f"empty bone name for pose {pose}")
-                                    continue
-
-                                pose_bone: bpy.types.PoseBone = get_case_insensitive(armature.pose.bones, bone_name)
-                                if not pose_bone:
-                                    # For cases where pose data tries to move a non-existent bone
-                                    # i.e. Poseidon has no 'Tongue' but its in the pose asset
-                                    if is_head:
-                                        # There are likely many missing bones in non-Head parts, but we
-                                        # process as many as we can.
-                                        Log.warn(f"could not find: {bone_name} for pose {pose_name}")
-                                    continue
-
-                                # Reset bone to identity
-                                pose_bone.matrix_basis.identity()
-
-                                rotation = bone.get('Rotation')
-                                assert rotation.get('IsNormalized'), "non-normalized rotation unsupported"
-
-                                edit_bone = pose_bone.bone
-                                post_quat = Quaternion(post_quat) if (post_quat := edit_bone.get("post_quat")) else Quaternion()
-
-                                q = post_quat.copy()
-                                q.rotate(make_quat(rotation))
-                                quat = post_quat.copy()
-                                quat.rotate(q.conjugated())
-                                pose_bone.rotation_quaternion = quat.conjugated() @ pose_bone.rotation_quaternion
-
-                                loc = (make_vector(bone.get('Location'), mirror_y=True))
-                                loc = Vector((loc.x * face_attach_scale.x,
-                                              loc.y * face_attach_scale.y,
-                                              loc.z * face_attach_scale.z))
-                                loc.rotate(post_quat.conjugated())
-
-                                pose_bone.location = pose_bone.location + loc * loc_scale
-                                pose_bone.scale = (Vector((1, 1, 1)) + make_vector(bone.get('Scale')))
-
-                                pose_bone.rotation_quaternion.normalize()
-
-                            # Create blendshape from armature
-                            bpy.ops.object.mode_set(mode='OBJECT')
-                            bpy.context.view_layer.objects.active = imported_mesh
-                            bpy.ops.object.modifier_apply_as_shapekey(keep_modifier=True,
-                                                                      modifier=armature_modifier.name)
-
-                            # Use name from pose data
-                            imported_mesh.data.shape_keys.key_blocks[-1].name = pose_name
-
-                        # TODO: FishThicc triggers interesting curve data. Investigate tomorrow...
-                        for pose in pose_data:
-                            if not (curve_data := pose.get('CurveData')):
-                                continue
-
-                            # If there's curve data that's more than the
-                            # current pose being 1.0 and all other poses
-                            # non-zero, note that.
-                            curve_sum = sum([abs(x) for x in curve_data])
-                            if curve_sum and (curve_sum > 1.0001 or curve_sum < 0.999):
-                                Log.warn(f'{pose_name}: has interesting '
-                                         'curve data! Implement this feature...')
-                    except Exception as e:
-                        Log.error("Failed to import PoseAsset data from "
-                                  f"{imported_mesh.name}: {e}")
-                    finally:
-                        # Final reset before re-entering regular import mode.
-                        bpy.context.view_layer.objects.active = armature
-                        bpy.ops.object.mode_set(mode='POSE')
-                        bpy.ops.pose.select_all(action='SELECT')
-                        bpy.ops.pose.transforms_clear()
-                        bpy.ops.pose.select_all(action='DESELECT')
-                        bpy.ops.object.mode_set(mode=original_mode)
             case _:
                 meta = {}
+
+        # fetch pose data
+        meta.update(get_meta(["PoseData", "ReferencePose"]))
+        if (pose_data := meta.get("PoseData")):
+            is_head = mesh_type == "Head"
+            shape_keys = imported_mesh.data.shape_keys
+            armature: bpy.types.Object = imported_object
+            original_mode = bpy.context.active_object.mode
+            try:
+                bpy.ops.object.mode_set(mode='OBJECT')
+                armature_modifier: bpy.types.ArmatureModifier = first(imported_mesh.modifiers, lambda mod: mod.type == "ARMATURE")
+
+                # Grab reference pose data
+                reference_pose = meta.get("ReferencePose", dict())
+
+                # Check how many bones are scaled in the reference pose
+                face_attach_scale = Vector((1, 1, 1))
+                for entry in reference_pose:
+                    scale = make_vector(entry.get('Scale'))
+                    if scale != Vector((1, 1, 1)):
+                        if entry.get('BoneName', '').casefold() == 'faceattach':
+                            face_attach_scale = scale
+                        Log.warn(f"Non-zero scale: {entry}")
+
+                if not shape_keys:
+                    # Create Basis shape key
+                    imported_mesh.shape_key_add(name="Basis", from_mix=False)
+
+                # NOTE: I think faceAttach affects the expected location
+                # I'm making this assumption from observation of an old
+                # export of face poses for Polar Patroller.
+                loc_scale = (0.01 if self.options.get("ScaleDown") else 1)
+                for pose in pose_data:
+                    # If there are no influences, don't bother
+                    if not (influences := pose.get('Keys')):
+                        continue
+
+                    if not (pose_name := pose.get('Name')):
+                        Log.warn("skipping pose data with no pose name")
+                        continue
+
+                    # Enter pose mode
+                    bpy.context.view_layer.objects.active = armature
+                    bpy.ops.object.mode_set(mode='POSE')
+
+                    # Reset all transforms to default
+                    bpy.ops.pose.select_all(action='SELECT')
+                    bpy.ops.pose.transforms_clear()
+                    bpy.ops.pose.select_all(action='DESELECT')
+
+                    # Move bones accordingly
+                    for bone in influences:
+                        if not (bone_name := bone.get('Name')):
+                            Log.warn(f"empty bone name for pose {pose}")
+                            continue
+
+                        pose_bone: bpy.types.PoseBone = get_case_insensitive(armature.pose.bones, bone_name)
+                        if not pose_bone:
+                            # For cases where pose data tries to move a non-existent bone
+                            # i.e. Poseidon has no 'Tongue' but it's in the pose asset
+                            if is_head:
+                                # There are likely many missing bones in non-Head parts, but we
+                                # process as many as we can.
+                                Log.warn(f"could not find: {bone_name} for pose {pose_name}")
+                            continue
+
+                        # Reset bone to identity
+                        pose_bone.matrix_basis.identity()
+
+                        rotation = bone.get('Rotation')
+                        assert rotation.get('IsNormalized'), "non-normalized rotation unsupported"
+
+                        edit_bone = pose_bone.bone
+                        post_quat = Quaternion(post_quat) if (post_quat := edit_bone.get("post_quat")) else Quaternion()
+
+                        q = post_quat.copy()
+                        q.rotate(make_quat(rotation))
+                        quat = post_quat.copy()
+                        quat.rotate(q.conjugated())
+                        pose_bone.rotation_quaternion = quat.conjugated() @ pose_bone.rotation_quaternion
+
+                        loc = (make_vector(bone.get('Location'), mirror_y=True))
+                        loc = Vector((loc.x * face_attach_scale.x,
+                                        loc.y * face_attach_scale.y,
+                                        loc.z * face_attach_scale.z))
+                        loc.rotate(post_quat.conjugated())
+
+                        pose_bone.location = pose_bone.location + loc * loc_scale
+                        pose_bone.scale = (Vector((1, 1, 1)) + make_vector(bone.get('Scale')))
+
+                        pose_bone.rotation_quaternion.normalize()
+
+                    # Create blendshape from armature
+                    bpy.ops.object.mode_set(mode='OBJECT')
+                    bpy.context.view_layer.objects.active = imported_mesh
+                    bpy.ops.object.modifier_apply_as_shapekey(keep_modifier=True,
+                                                                modifier=armature_modifier.name)
+
+                    # Use name from pose data
+                    imported_mesh.data.shape_keys.key_blocks[-1].name = pose_name
+
+                # TODO: FishThicc triggers interesting curve data. Investigate tomorrow...
+                for pose in pose_data:
+                    if not (curve_data := pose.get('CurveData')):
+                        continue
+
+                    # If there's curve data that's more than the
+                    # current pose being 1.0 and all other poses
+                    # non-zero, note that.
+                    curve_sum = sum([abs(x) for x in curve_data])
+                    if curve_sum and (curve_sum > 1.0001 or curve_sum < 0.999):
+                        Log.warn(f'{pose_name}: has interesting '
+                                    'curve data! Implement this feature...')
+            except Exception as e:
+                Log.error("Failed to import PoseAsset data from "
+                            f"{imported_mesh.name}: {e}")
+            finally:
+                # Final reset before re-entering regular import mode.
+                bpy.context.view_layer.objects.active = armature
+                bpy.ops.object.mode_set(mode='POSE')
+                bpy.ops.pose.select_all(action='SELECT')
+                bpy.ops.pose.transforms_clear()
+                bpy.ops.pose.select_all(action='DESELECT')
+                bpy.ops.object.mode_set(mode=original_mode)
 
         if self.options.get("UseQuads"):
             bpy.context.view_layer.objects.active = imported_mesh

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -650,6 +650,7 @@ class DataImportTask:
                     bpy.ops.pose.select_all(action='DESELECT')
 
                     # Move bones accordingly
+                    contributed = False
                     for bone in influences:
                         if not (bone_name := bone.get('Name')):
                             Log.warn(f"empty bone name for pose {pose}")
@@ -663,6 +664,11 @@ class DataImportTask:
                                 # There are likely many missing bones in non-Head parts, but we
                                 # process as many as we can.
                                 Log.warn(f"could not find: {bone_name} for pose {pose_name}")
+                            continue
+
+                        # Check if there's a vertex group associated with the pose bone
+                        # If not, no reason to pose it.
+                        if pose_bone.name not in imported_mesh.vertex_groups:
                             continue
 
                         # Reset bone to identity
@@ -690,6 +696,11 @@ class DataImportTask:
                         pose_bone.scale = (Vector((1, 1, 1)) + make_vector(bone.get('Scale')))
 
                         pose_bone.rotation_quaternion.normalize()
+                        contributed = True
+
+                    # Do not create shape keys if nothing changed
+                    if not contributed:
+                        continue
 
                     # Create blendshape from armature
                     bpy.ops.object.mode_set(mode='OBJECT')

--- a/FortnitePorting/ViewModels/CUE4ParseViewModel.cs
+++ b/FortnitePorting/ViewModels/CUE4ParseViewModel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using CUE4Parse.Compression;
 using CUE4Parse.Encryption.Aes;
 using CUE4Parse.MappingsProvider;
 using CUE4Parse.UE4.AssetRegistry;
@@ -76,6 +77,10 @@ public class CUE4ParseViewModel : ViewModelBase
 
     public override async Task Initialize()
     {
+        HomeVM.Update("Initializing Libraries");
+        await InitializeOodle();
+        await InitializeZlib();
+        
         HomeVM.Update("Loading Game Archive");
         await InitializeProvider();
         if ((AppSettings.Current.UseCosmeticStreaming && AppSettings.Current.LoadingType == ELoadingType.Local) || AppSettings.Current.LoadingType == ELoadingType.Live) await LoadCosmeticStreaming();
@@ -94,6 +99,36 @@ public class CUE4ParseViewModel : ViewModelBase
 
         HomeVM.Update("Loading Application Assets");
         await LoadRequiredAssets();
+    }
+
+    private async Task InitializeOodle()
+    {
+        var oodlePath = Path.Combine(DataFolder.FullName, OodleHelper.OODLE_DLL_NAME);
+        if (File.Exists(OodleHelper.OODLE_DLL_NAME))
+        {
+            File.Move(OodleHelper.OODLE_DLL_NAME, oodlePath, true);
+        }
+        else if (!File.Exists(oodlePath))
+        {
+            await OodleHelper.DownloadOodleDllAsync(oodlePath);
+        }
+        
+        OodleHelper.Initialize(oodlePath);
+    }
+    
+    private async Task InitializeZlib()
+    {
+        var zlibPath = Path.Combine(DataFolder.FullName, ZlibHelper.DLL_NAME);
+        if (File.Exists(ZlibHelper.DLL_NAME))
+        {
+            File.Move(ZlibHelper.DLL_NAME, zlibPath, true);
+        }
+        else if (!File.Exists(zlibPath))
+        {
+            await ZlibHelper.DownloadDllAsync(zlibPath);
+        }
+        
+        ZlibHelper.Initialize(zlibPath);
     }
 
     private async Task InitializeProvider()


### PR DESCRIPTION
**Summary**

This is initial support for converting Unreal Engine Pose Assets to Blender shape keys. It integrates fairly seamlessly with the existing Blender plugin. The motivation here is that I suck at making shape keys by hand, so I did the logical thing which was spend more time than the initial manual process to automate it 😄.

Unfortunately, there are still some characters which appear to be using some other method to drive facial flexes (i.e. Hulk), so this won't cover everything.

I've added some rather hacky support for facial flexes to influence the mesh found in `FaceAcc` / `CustomCharacterFaceData` (?). Any tips on how to improve this aspect of the code would be greatly appreciated. Alternatively, I am OK with contributors directlying comitting to this PR.

If you'd like to contact me directly, please ping me in the Discord @RedHaze.

**ToDo**

- [x] Maybe a nicer way to know when to propagate pose data? Is this something available in Anim BP?
- [x] Pruning blend shapes that have no influence on vertex groups according to pose bones.
- [x] ~~Look into Fish Thicc's use of `CurveData` and why it's triggering warnings.~~ will be done later if there's demand
- [x] ~~Implement (or remove?) `CurveData` processing in the Blender plugin based on findings.~~ will be done later if there's demand
- [ ] Strange issues with eye lids (`R_upperLidDown_pose` vs `L_upperLidDown_pose` where R is clearly wrong) when importing Fish Thicc
- [ ] Grriz has pose data, but there's a bug of some sort preventing proper import (possibly because it is essentially two characters in one)
