### PR TITLE
Fix unintentional pose bone skipping when processing pose assets

### DIFF
--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -710,7 +710,7 @@ class DataImportTask:
                         pose_bone.rotation_quaternion.normalize()
                         contributed = True
 
-                    # Fast check: Do not create shape keys if no bones moved
+                    # Do not create shape keys if nothing changed
                     if not contributed:
                         continue
 
@@ -719,6 +719,8 @@ class DataImportTask:
                     bpy.context.view_layer.objects.active = imported_mesh
                     bpy.ops.object.modifier_apply_as_shapekey(keep_modifier=True,
                                                                 modifier=armature_modifier.name)
+
+                    # Use name from pose data
                     imported_mesh.data.shape_keys.key_blocks[-1].name = pose_name
             except Exception as e:
                 Log.error("Failed to import PoseAsset data from "

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -4,8 +4,6 @@ import json
 import re
 import bmesh
 import traceback
-import numpy as np
-from numpy.typing import NDArray
 from enum import Enum
 from math import radians
 from mathutils import Matrix, Vector, Euler, Quaternion
@@ -640,13 +638,6 @@ class DataImportTask:
                     # Create Basis shape key
                     imported_mesh.shape_key_add(name="Basis", from_mix=False)
 
-                # WARNING: Assumption is that all created shape keys use the
-                # Basis shape key as the relative key.
-                basis_shape_key = imported_mesh.data.shape_keys.key_blocks[0]
-                basis_shape_key_values = np.empty(
-                    len(basis_shape_key.data) * 3, dtype=np.single)
-                basis_shape_key.data.foreach_get("co", basis_shape_key_values)
-
                 # NOTE: I think faceAttach affects the expected location
                 # I'm making this assumption from observation of an old
                 # export of face poses for Polar Patroller.
@@ -671,7 +662,6 @@ class DataImportTask:
 
                     # Move bones accordingly
                     contributed = False
-                    skip_slow_check = False
                     for bone in influences:
                         if not (bone_name := bone.get('Name')):
                             Log.warn(f"empty bone name for pose {pose}")
@@ -687,12 +677,9 @@ class DataImportTask:
                                 Log.warn(f"could not find: {bone_name} for pose {pose_name}")
                             continue
 
-                        # If there's a vertex group associated with the pose
-                        # bone then there's at least some vertices that are
-                        # being affected. Therefore, no need to execute the
-                        # much slower basis <-> new shape key difference check.
-                        if not skip_slow_check and pose_bone.name in imported_mesh.vertex_groups:
-                            skip_slow_check = True
+                        # Verify that the current bone and all of its children
+                        # have at least one vertex group associated with it
+                        if not bone_hierarchy_has_vertex_groups(pose_bone, imported_mesh.vertex_groups):
                             continue
 
                         # Reset bone to identity
@@ -732,21 +719,7 @@ class DataImportTask:
                     bpy.context.view_layer.objects.active = imported_mesh
                     bpy.ops.object.modifier_apply_as_shapekey(keep_modifier=True,
                                                                 modifier=armature_modifier.name)
-
-                    shape_key = imported_mesh.data.shape_keys.key_blocks[-1]
-
-                    # Slow check: Ensure shape key changed from basis. Helps
-                    # catch edge cases like the Jaw in metahuman characters
-                    # being driven by a parent bone which has no associated
-                    # vertex groups
-                    if not skip_slow_check and not shape_key_differs_from_basis(shape_key, basis_shape_key_values):
-                        # Remove created shape key
-                        imported_mesh.active_shape_key_index = len(imported_mesh.data.shape_keys.key_blocks) - 1
-                        bpy.ops.object.shape_key_remove()
-                        continue
-
-                    # Use name from pose data
-                    shape_key.name = pose_name
+                    imported_mesh.data.shape_keys.key_blocks[-1].name = pose_name
             except Exception as e:
                 Log.error("Failed to import PoseAsset data from "
                             f"{imported_mesh.name}: {e}")
@@ -1553,17 +1526,15 @@ def clear_bone_poses_recursive(skeleton, anim, bone_name):
             anim.fcurves.remove(fcurve)
     bpy.ops.object.mode_set(mode='OBJECT')
 
-def shape_key_differs_from_basis(shape_key: bpy.types.ShapeKey,
-                                 basis_shape_key_values: NDArray[np.single]):
-    num_vertices = len(shape_key.data) * 3
-    assert num_vertices == len(basis_shape_key_values), "mismatched vertices size"
-    vertices = np.empty(num_vertices, dtype=np.single)
-    shape_key.data.foreach_get('co', vertices)
-    return not np.allclose(vertices,
-                           basis_shape_key_values,
-                           rtol=1e-03,
-                           atol=1e-07,
-                           equal_nan=True)
+def bone_hierarchy_has_vertex_groups(bone, vertex_groups):
+    # Traverse down bone hierarchy until at least one child bone or itself has
+    # an associated vertex group.
+    bone_list = [bone]
+    while bone_list and (curr_bone := bone_list.pop()):
+        if curr_bone.name in vertex_groups:
+            return True
+        bone_list.extend(bone.children)
+    return False
 
 class LazyInit:
     


### PR DESCRIPTION
**Summary**

I made the incorrect assumption that only the bone being transformed as part of a pose may or may not be skipped based on whether or not it has an active associated vertex group. This is true for most cases, however, for metahumans, the bone `FACIAL_C_LowerLipRotation` is actually not a child of `FACIAL_C_Jaw` but rather a child of `FACIAL_C_FacialRoot`.

I double checked the pose asset and `FACIAL_C_LowerLipRotation` is in-fact driven separately. It was incorrectly being excluded from the final pose since `FACIAL_C_LowerLipRotation` has no associated vertex group, however, its children's bones _do_ have associated vertex groups.

Therefore, I updated the logic to only skip posing if the bone being posed _and all of its children_ have no associated vertex groups.