### PR TITLE
Fix bug where metadata unintentionally overwritten during Blender import

### DIFF
--- a/FortnitePorting/Export/Types/MeshExportData.cs
+++ b/FortnitePorting/Export/Types/MeshExportData.cs
@@ -52,8 +52,6 @@ public class MeshExportData : ExportDataBase
                     }
                 }
 
-                ExportPartMeta? partWithPoseData = null;
-                var exportPartsToCopyTo = new List<ExportPartMeta>();
                 AssetsVM.ExportChunks = parts.Length;
                 foreach (var part in parts)
                 {
@@ -62,33 +60,8 @@ public class MeshExportData : ExportDataBase
                         Animation = AnimExportData.From(montage, exportType);
                     }
 
-                    var resolvedPart = Exporter.CharacterPart(part);
-                    var meta = resolvedPart?.Meta;
-                    if (meta is not null)
-                    {
-                        if (meta.PoseData.Count != 0)
-                        {
-                            if (partWithPoseData != null)
-                                Log.Warning("multiple character parts contained PoseData, results may be inaccurate");
-                            partWithPoseData = meta;
-                        }
-                        else
-                        {
-                            exportPartsToCopyTo.Add(meta);
-                        }
-                    }
-                    Meshes.AddIfNotNull(resolvedPart);
+                    Meshes.AddIfNotNull(Exporter.CharacterPart(part));
                     AssetsVM.ExportProgress++;
-                }
-
-                // Copy data around
-                if (partWithPoseData is not null) 
-                {
-                    foreach (var part in exportPartsToCopyTo)
-                    {
-                        part.PoseData = partWithPoseData.PoseData;
-                        part.ReferencePose = partWithPoseData.ReferencePose;
-                    }
                 }
 
                 if (Animation is null && Exporter.AppExportOptions.LobbyPoses && Meshes.FirstOrDefault(part => part is ExportPart { CharacterPartType: EFortCustomPartType.Body }) is ExportPart foundPart)

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -594,6 +594,13 @@ class DataImportTask:
                     
                 for search_prop in search_props:
                     if found_key := first(meta.keys(), lambda key: key == search_prop):
+                        if out_props.get(found_key):
+                            if meta.get(found_key):
+                                Log.warn(f"{found_key}: metadata already set "
+                                        "with content from different mesh but "
+                                        f"also found on {mesh.get('Name')} "
+                                        "which will be ignored")
+                            continue
                         out_props[found_key] = meta.get(found_key)
             return out_props
 


### PR DESCRIPTION
**Summary**

As part of the initial implementation of pose asset importing, I copied the data to all character parts to ensure stuff like `FaceAcc` or other parts have similar transforms applied. Interestingly, this didn't seem to work as expected with styles (specifically Shady Zadie unmasked).

I noticed there's likely no need to copy pose asset data around given all parts are accessible during `import_model` in `import_task.py`. It turns out that in `get_meta`, properties from the metadata would be taken from the last part to contain a key for that data, even if it were empty. So I added a check to make sure the key has non-empty data associated with it when assigning to `out_props`.

Since `get_meta` for pose asset data is run for all parts, it should capture non-empty pose asset data from at least one of the parts if there's any available. So there shouldn't be any need to copy around pose asset data to all parts from C#. A warning in Blender console will print if multiple parts contain data of the same key. When this happens, later non-empty data is ignored.