### PR TITLE
Fixing shapekey issue and Tasty Rig deform bone scaling when scaleDown=false

### DIFF
--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -184,7 +184,7 @@ public class ExporterInstance
                             ParsePoseAsset(poseAssetNode.Get<UPoseAsset>("PoseAsset"), meta);
                         }
                         else if (skeletalMesh.ReferenceSkeleton.FinalRefBoneInfo.Any(bone => bone.Name.Text.Equals("FACIAL_C_FacialRoot", StringComparison.OrdinalIgnoreCase))
-                                 && CUE4ParseVM.Provider.TryLoadObject("FortniteGame/Content/Characters/Player/Male/Medium/Heads/M_MED_Jonesy3L_Head/Meshes/3L/3L_lod2_Facial_Poses_PoseAsset", out UPoseAsset poseAsset))
+                                 && CUE4ParseVM.Provider.TryLoadObject("/BRCosmetics/Characters/Player/Male/Medium/Heads/M_MED_Jonesy3L_Head/Meshes/3L/3L_lod2_Facial_Poses_PoseAsset", out UPoseAsset poseAsset))
                         {
                             ParsePoseAsset(poseAsset, meta);
                         }

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -1909,7 +1909,7 @@ def apply_tasty_rig(master_skeleton, scale, use_finger_ik = True, use_dyn_bone_s
         if "deform_" in bone.name:
             deform_collection.assign(bone)
             bone.custom_shape = bpy.data.objects.get('RIG_Tweak')
-            bone.custom_shape_scale_xyz = (0.030, 0.030, 0.030) * scale
+            bone.custom_shape_scale_xyz = Vector((0.030, 0.030, 0.030)) * scale
             bone.use_custom_shape_bone_size = False
             continue
             


### PR DESCRIPTION
When exporting a skin with the Tasty (IK) rig and Scale Down set to false, the plugin would fail in the middle of setting up the Tasty Rig (on line 1912), causing the IK components to not get set up.  The issue was that in python, (x, y, z) * 100 is (x, y, z, x, y, z,, ... ) instead of (100x, 100y, 100z).  It looks like other places above used Vector(x, y, z) when multiplying with scale, so I changed the line that was throwing the error to the same format