### PR TITLE
Fixing Resources and FortWeaponRangedItem Asset Exporting

### DIFF
--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -184,7 +184,7 @@ public class ExporterInstance
                             ParsePoseAsset(poseAssetNode.Get<UPoseAsset>("PoseAsset"), meta);
                         }
                         else if (skeletalMesh.ReferenceSkeleton.FinalRefBoneInfo.Any(bone => bone.Name.Text.Equals("FACIAL_C_FacialRoot", StringComparison.OrdinalIgnoreCase))
-                                 && CUE4ParseVM.Provider.TryLoadObject("FortniteGame/Content/Characters/Player/Male/Medium/Heads/M_MED_Jonesy3L_Head/Meshes/3L/3L_lod2_Facial_Poses_PoseAsset", out UPoseAsset poseAsset))
+                                 && CUE4ParseVM.Provider.TryLoadObject("/BRCosmetics/Characters/Player/Male/Medium/Heads/M_MED_Jonesy3L_Head/Meshes/3L/3L_lod2_Facial_Poses_PoseAsset", out UPoseAsset poseAsset))
                         {
                             ParsePoseAsset(poseAsset, meta);
                         }

--- a/FortnitePorting/Export/ExporterInstance.cs
+++ b/FortnitePorting/Export/ExporterInstance.cs
@@ -280,6 +280,17 @@ public class ExporterInstance
             }
         }
 
+        if (exportWeapons.Count == 0 && weaponDefinition.TryGetValue(out FInstancedStruct[] dataList, "DataList"))
+        {
+            foreach (var data in dataList)
+            {
+                if (data.NonConstStruct?.TryGetValue(out UObject mesh, "PickupSkeletalMesh", "PickupStaticMesh") ?? false)
+                {
+                    exportWeapons.Add(mesh);
+                }
+            }
+        }
+
         return exportWeapons;
     }
 

--- a/FortnitePorting/Plugins/Blender/import_task.py
+++ b/FortnitePorting/Plugins/Blender/import_task.py
@@ -1909,7 +1909,7 @@ def apply_tasty_rig(master_skeleton, scale, use_finger_ik = True, use_dyn_bone_s
         if "deform_" in bone.name:
             deform_collection.assign(bone)
             bone.custom_shape = bpy.data.objects.get('RIG_Tweak')
-            bone.custom_shape_scale_xyz = (0.030, 0.030, 0.030) * scale
+            bone.custom_shape_scale_xyz = Vector((0.030, 0.030, 0.030)) * scale
             bone.use_custom_shape_bone_size = False
             continue
             


### PR DESCRIPTION
Resources and FortWeaponRangedItem Assets use the "PickupSkeletalMesh" and "PickupStaticMesh" definitions in the DataList property for their mesh definitions, which was previously not included (resulting in an empty collection being imported in blender).

Note: The changes from my other PR were included in this PR because GitHub wouldn't let me create a separate fork or make a new branch off of the base v2, so I had to make this branch off of my modified v2 (since I was dumb and didn't keep a base v2 in my fork)