### PR TITLE
Fixing icon retrieval after 30.10 update

### DIFF
--- a/FortnitePorting.Framework/ViewModels/EndpointViewModelBase.cs
+++ b/FortnitePorting.Framework/ViewModels/EndpointViewModelBase.cs
@@ -13,7 +13,7 @@ public abstract class EndpointViewModelBase : ViewModelBase
         Client = new RestClient(new RestClientOptions
         {
             UserAgent = userAgent,
-            MaxTimeout = 1000 * 10
+            MaxTimeout = 1000 * 300
         }, configureSerialization: s => s.UseSerializer<JsonNetSerializer>());
     }
 

--- a/FortnitePorting.Framework/ViewModels/Endpoints/Models/ReleaseResponse.cs
+++ b/FortnitePorting.Framework/ViewModels/Endpoints/Models/ReleaseResponse.cs
@@ -65,6 +65,18 @@ public class FPVersion
         return MajorEquals(other) && MinorEquals(other) && PatchEquals(other);
     }
 
+    /**
+     * Check if the current version is newer than the version passed as the parameter
+     * Returns: True if this is newer than obj, false otherwise
+     */
+    public bool IsNewer(object? obj)
+    {
+        var other = (FPVersion) obj!;
+        return Major > other.Major 
+               || (Major == other.Major && Minor > other.Minor)
+               || (Major == other.Major && Minor == other.Minor && Patch > other.Patch);
+    }
+
     public override int GetHashCode()
     {
         return HashCode.Combine(Major, Minor, Patch);

--- a/FortnitePorting/Globals.cs
+++ b/FortnitePorting/Globals.cs
@@ -8,7 +8,7 @@ namespace FortnitePorting;
 
 public static class Globals
 {
-    public static readonly FPVersion Version = new(2, 1, 8);
+    public static readonly FPVersion Version = new(2, 1, 9);
     public static readonly string VersionString = Version.ToString();
 
     public const string DISCORD_URL = "https://discord.gg/DZ5YFXdBA6";

--- a/FortnitePorting/Plugins/Blender/FortnitePorting/__init__.py
+++ b/FortnitePorting/Plugins/Blender/FortnitePorting/__init__.py
@@ -10,7 +10,7 @@ bl_info = {
     "description": "Fortnite Porting Blender Plugin",
     "author": "Half",
     "blender": (4, 0, 0),
-    "version": (2, 1, 8),
+    "version": (2, 1, 9),
     "category": "Import",
 }
 

--- a/FortnitePorting/ViewModels/MainViewModel.cs
+++ b/FortnitePorting/ViewModels/MainViewModel.cs
@@ -26,7 +26,7 @@ public partial class MainViewModel : ViewModelBase
     public override async Task Initialize()
     {
         await RefreshUpdateInfo();
-        if (AvailableUpdate is not null && !AvailableUpdate.ProperVersion.Equals(Globals.Version))
+        if (AvailableUpdate is not null && AvailableUpdate.ProperVersion.IsNewer(Globals.Version))
         {
             UpdateText = $"Update to\nv{AvailableUpdate.Version}";
 
@@ -56,7 +56,7 @@ public partial class MainViewModel : ViewModelBase
 
     public async Task UpdatePrompt()
     {
-        if (AvailableUpdate is not null && !AvailableUpdate.ProperVersion.Equals(Globals.Version))
+        if (AvailableUpdate is not null && AvailableUpdate.ProperVersion.IsNewer(Globals.Version))
         {
             MessageWindow.Show(new MessageWindowModel
             {


### PR DESCRIPTION
Icon paths were moved from AthenaCharacterItemDefinition.HeroDefinition.Properties to AthenaCharacterItemDefinition.HeroDefinition.DataList.Properties and had their names changed from PreviewImage to Icon.

Also added logic to check that the incoming update version is newer than the current version, to avoid "You're using 2.1.9, do you want to update to 2.1.8" messages