### PR TITLE
Fixing lobby pose prop and character accessory importing

### DIFF
--- a/FortnitePorting/Plugins/Blender/FortnitePorting/import_task.py
+++ b/FortnitePorting/Plugins/Blender/FortnitePorting/import_task.py
@@ -696,7 +696,7 @@ class DataImportTask:
 
         # fetch pose data
         meta = get_meta(["PoseData", "ReferencePose"])
-        if (pose_data := meta.get("PoseData")):
+        if (pose_data := meta.get("PoseData") and imported_mesh is not None):
             is_head = mesh_type == "Head"
             shape_keys = imported_mesh.data.shape_keys
             armature: bpy.types.Object = imported_object
@@ -1457,6 +1457,7 @@ def constraint_object(child: bpy.types.Object, parent: bpy.types.Object, bone: s
     constraint.subtarget = bone
     child.rotation_mode = 'XYZ'
     child.rotation_euler = rot
+    child.location = Vector((0, 0, 0))
     constraint.inverse_matrix = Matrix()
 
 


### PR DESCRIPTION
Two issues fixed:

1) When importing a skin that has a lobby pose with props, the plugin would throw an error when trying to get the shape keys for the master_skeleton/Fortnite_M_Avg_Player_Skeleton's mesh (because it doesn't exist).  Fixed by adding a null check before trying to get the shape keys/process the pose data

2) When importing a skin that has an accessory (hat/custom head/tail/etc) that is connected to the main armature with a Child-Of constraint instead of by merging skeletons, if "Spawn at 3d Cursor" is enabled the accessory will end up offset from the main armature (both when spawned in and when moving the main armature in object mode).  Fixed by setting accessory armature object location to (0, 0, 0) when adding the Child-Of constraint, so the armature's position is determined by the constraint instead of by the constraint + the 3d cursor offset