### PR TITLE
Fix import of PoseData

### DIFF
--- a/FortnitePorting/Plugins/Blender/FortnitePorting/import_task.py
+++ b/FortnitePorting/Plugins/Blender/FortnitePorting/import_task.py
@@ -696,7 +696,7 @@ class DataImportTask:
 
         # fetch pose data
         meta = get_meta(["PoseData", "ReferencePose"])
-        if (pose_data := meta.get("PoseData") and imported_mesh is not None):
+        if imported_mesh is not None and (pose_data := meta.get("PoseData")):
             is_head = mesh_type == "Head"
             shape_keys = imported_mesh.data.shape_keys
             armature: bpy.types.Object = imported_object


### PR DESCRIPTION
In #62, the following was added when grabbing `PoseData`:
```python
if (pose_data := meta.get("PoseData") and imported_mesh is not None):
```

This actually sets `pose_data` to a boolean value which later results in the error:
```
[FNPORTING] Failed to import PoseAsset data from ...: 'bool' object is not iterable
```

This PR performs the check outside of the context of the variable set.