### PR TITLE
fix: remove custom icon handler for outfits

### DIFF
--- a/FortnitePorting/ViewModels/AssetsViewModel.cs
+++ b/FortnitePorting/ViewModels/AssetsViewModel.cs
@@ -134,20 +134,7 @@ public partial class AssetsViewModel : ViewModelBase
             {
                 Classes = ["AthenaCharacterItemDefinition"],
                 Filters = ["_NPC", "_TBD", "CID_VIP", "_Creative", "_SG"],
-                DisAllowNames = ["Bean_"],
-                IconHandler = asset =>
-                {
-                    asset.TryGetValue(out UTexture2D? previewImage, "SmallPreviewImage", "LargePreviewImage");
-                    if (previewImage is null && asset.TryGetValue(out UObject heroDef, "HeroDefinition"))
-                    {
-                        previewImage = AssetLoader.GetAssetIcon(heroDef);
-                        previewImage ??= heroDef.GetAnyOrDefault<UTexture2D>("SmallPreviewImage", "LargePreviewImage");
-
-                    }
-
-                    previewImage ??= AssetLoader.GetAssetIcon(asset);
-                    return previewImage;
-                }
+                DisAllowNames = ["Bean_", "CID_Bean"]
             },
 
             new(EAssetType.LegoOutfit)


### PR DESCRIPTION
I believe none of the outfits have a `SmallPreviewImage` and `LargePreviewImage` anymore. We are able to get the icons from the default `IconHandler` itself. so removed it.

`CID_Bean` also doesn't have any icon or anything. So added it to `DisAllowNames` although I am not sure what a 'Bean' outfit is.