### PR TITLE
 fix: Asset icon access order

### DIFF
--- a/FortnitePorting/ViewModels/AssetsViewModel.cs
+++ b/FortnitePorting/ViewModels/AssetsViewModel.cs
@@ -134,7 +134,21 @@ public partial class AssetsViewModel : ViewModelBase
             {
                 Classes = ["AthenaCharacterItemDefinition"],
                 Filters = ["_NPC", "_TBD", "CID_VIP", "_Creative", "_SG"],
-                DisAllowNames = ["Bean_", "CID_Bean"]
+                DisAllowNames = ["Bean_"],
+                IconHandler = asset =>
+                {
+                    UTexture2D? previewImage = AssetLoader.GetAssetIcon(asset);
+                    if (previewImage is null) {
+                        asset.TryGetValue(out previewImage, "SmallPreviewImage", "LargePreviewImage");
+                    }
+                    if (previewImage is null && asset.TryGetValue(out UObject heroDef, "HeroDefinition"))
+                    {
+                        previewImage = AssetLoader.GetAssetIcon(heroDef);
+                        previewImage ??= heroDef.GetAnyOrDefault<UTexture2D>("SmallPreviewImage", "LargePreviewImage");
+                    }
+                    
+                    return previewImage;
+                }
             },
 
             new(EAssetType.LegoOutfit)

--- a/FortnitePorting/ViewModels/AssetsViewModel.cs
+++ b/FortnitePorting/ViewModels/AssetsViewModel.cs
@@ -134,20 +134,7 @@ public partial class AssetsViewModel : ViewModelBase
             {
                 Classes = ["AthenaCharacterItemDefinition"],
                 Filters = ["_NPC", "_TBD", "CID_VIP", "_Creative", "_SG"],
-                DisAllowNames = ["Bean_"],
-                IconHandler = asset =>
-                {
-                    asset.TryGetValue(out UTexture2D? previewImage, "SmallPreviewImage", "LargePreviewImage");
-                    if (previewImage is null && asset.TryGetValue(out UObject heroDef, "HeroDefinition"))
-                    {
-                        previewImage = AssetLoader.GetAssetIcon(heroDef);
-                        previewImage ??= heroDef.GetAnyOrDefault<UTexture2D>("SmallPreviewImage", "LargePreviewImage");
-
-                    }
-
-                    previewImage ??= AssetLoader.GetAssetIcon(asset);
-                    return previewImage;
-                }
+                DisAllowNames = ["Bean_", "CID_Bean"]
             },
 
             new(EAssetType.LegoOutfit)


### PR DESCRIPTION
Follow up for #72. If it first accesses the one from hero definition for `Character_CattleJar` - `Meowtooth`, the icon is `T_Placeholder_Item_Outfit-S` whereas the actual icon is `T_Soldier_CattleJar`. Similar issue with Nix Scarlet and few others.

So changed the order to 
1. Get the icon from default method.
2. If not found, try to get from `SmallPreviewImage` and `LargePreviewImage`.
3. If not found, try to get from hero definition.