### PR TITLE
Add support for `CurveData` import & fixed some bugs with standalone `PoseAsset` imports

### DIFF
--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
@@ -56,7 +56,7 @@ class ImportContext:
                 self.import_font_data(data)
                 pass
             case EPrimitiveExportType.POSE_ASSET:
-                self.import_pose_asset_data(data)
+                self.import_pose_asset_data(data, get_selected_armature(), None)
                 pass
 
     def import_mesh_data(self, data):
@@ -230,131 +230,13 @@ class ImportContext:
 
         # metadata handling
         # todo extract meta reading to function bc this is too big
-        meta = self.gather_metadata("PoseData")
+        meta = self.gather_metadata("PoseData", "CurveTrackNames")
 
         # pose asset
-        if imported_mesh is not None and (pose_data := meta.get("PoseData")):
-            shape_keys = imported_mesh.data.shape_keys
-            armature = imported_object
-            original_mode = bpy.context.active_object.mode
-            try:
-                bpy.ops.object.mode_set(mode='OBJECT')
-                armature_modifier: bpy.types.ArmatureModifier = first(imported_mesh.modifiers, lambda mod: mod.type == "ARMATURE")
+        if imported_mesh is not None:
+            bpy.context.view_layer.objects.active = imported_mesh
+            self.import_pose_asset_data(meta, get_selected_armature(), part_type)
 
-                if not shape_keys:
-                    # Create Basis shape key
-                    imported_mesh.shape_key_add(name="Basis", from_mix=False)
-
-                root_bone_name = 'neck_01'
-                root_bone = get_case_insensitive(armature.pose.bones, root_bone_name)
-                if not root_bone:
-                    Log.warn(f"{imported_mesh.name}: Failed to find root bone "
-                             f"'{root_bone_name}' in '{armature.name}', all "
-                             "bones will be considered during import of "
-                             "PoseData")
-
-                loc_scale = self.scale
-                for pose in pose_data:
-                    # If there are no influences, don't bother
-                    if not (influences := pose.get('Keys')):
-                        continue
-
-                    if not (pose_name := pose.get('Name')):
-                        Log.warn(f"{imported_mesh.name}: skipping pose data "
-                                 f"with no pose name: {pose}")
-                        continue
-
-                    # Enter pose mode
-                    bpy.context.view_layer.objects.active = armature
-                    bpy.ops.object.mode_set(mode='POSE')
-
-                    # Reset all transforms to default
-                    bpy.ops.pose.select_all(action='SELECT')
-                    bpy.ops.pose.transforms_clear()
-                    bpy.ops.pose.select_all(action='DESELECT')
-
-                    # Move bones accordingly
-                    contributed = False
-                    for bone in influences:
-                        if not (bone_name := bone.get('Name')):
-                            Log.warn(f"{imported_mesh.name} - {pose_name}: "
-                                     f"empty bone name for pose '{pose}'")
-                            continue
-
-                        pose_bone: bpy.types.PoseBone = get_case_insensitive(armature.pose.bones, bone_name)
-                        if not pose_bone:
-                            # For cases where pose data tries to move a non-existent bone
-                            # i.e. Poseidon has no 'Tongue' but it's in the pose asset
-                            if part_type is EFortCustomPartType.HEAD:
-                                # There are likely many missing bones in non-Head parts, but we
-                                # process as many as we can.
-                                Log.warn(f"{imported_mesh.name} - {pose_name}: "
-                                         f"'{bone_name}' influence skipped "
-                                         "since it was not found in "
-                                         f"'{armature.name}'")
-                            continue
-
-                        if root_bone and not bone_has_parent(pose_bone, root_bone):
-                            Log.warn(f"{imported_mesh.name} - {pose_name}: "
-                                     f"skipped '{pose_bone.name}' since it does "
-                                     f"not have '{root_bone.name}' as a parent")
-                            continue
-
-                        # Verify that the current bone and all of its children
-                        # have at least one vertex group associated with it
-                        if not bone_hierarchy_has_vertex_groups(pose_bone, imported_mesh.vertex_groups):
-                            continue
-
-                        # Reset bone to identity
-                        pose_bone.matrix_basis.identity()
-
-                        rotation = bone.get('Rotation')
-                        if not rotation.get('IsNormalized'):
-                            Log.warn(f"rotation not normalized for {bone_name} in pose {pose_name}")
-
-                        edit_bone = pose_bone.bone
-                        post_quat = Quaternion(post_quat) if (post_quat := edit_bone.get("post_quat")) else Quaternion()
-
-                        q = post_quat.copy()
-                        q.rotate(make_quat(rotation))
-                        quat = post_quat.copy()
-                        quat.rotate(q.conjugated())
-                        pose_bone.rotation_quaternion = quat.conjugated() @ pose_bone.rotation_quaternion
-
-                        loc = (make_vector(bone.get('Location'), unreal_coords_correction=True))
-                        loc.rotate(post_quat.conjugated())
-
-                        pose_bone.location = pose_bone.location + loc * loc_scale
-                        pose_bone.scale = (Vector((1, 1, 1)) + make_vector(bone.get('Scale')))
-
-                        pose_bone.rotation_quaternion.normalize()
-                        contributed = True
-
-                    # Do not create shape keys if nothing changed
-                    if not contributed:
-                        continue
-
-                    # Create blendshape from armature
-                    bpy.ops.object.mode_set(mode='OBJECT')
-                    bpy.context.view_layer.objects.active = imported_mesh
-                    imported_mesh.select_set(True)
-                    bpy.ops.object.modifier_apply_as_shapekey(keep_modifier=True,
-                                                              modifier=armature_modifier.name)
-
-                    # Use name from pose data
-                    imported_mesh.data.shape_keys.key_blocks[-1].name = pose_name
-            except Exception as e:
-                Log.error("Failed to import PoseAsset data from "
-                          f"{imported_mesh.name}: {e}")
-            finally:
-                # Final reset before re-entering regular import mode.
-                bpy.context.view_layer.objects.active = armature
-                bpy.ops.object.mode_set(mode='POSE')
-                bpy.ops.pose.select_all(action='SELECT')
-                bpy.ops.pose.transforms_clear()
-                bpy.ops.pose.select_all(action='DESELECT')
-                bpy.ops.object.mode_set(mode=original_mode)
-                
         # end
 
         match part_type:
@@ -1330,107 +1212,156 @@ class ImportContext:
         font_path = os.path.join(self.assets_root, file_path + ".ttf")
         bpy.ops.font.open(filepath=font_path, check_existing=True)
         
-    def import_pose_asset_data(self, data):
+    def import_pose_asset_data(self, data, selected_armature, part_type):
         pose_data = data.get("PoseData")
-        
+        if not pose_data:
+            return
+
+        tracks = data.get("CurveTrackNames")
+
         original_selected_object = bpy.context.active_object
-        selected_armature = get_selected_armature()
         if selected_armature is None:
             return
-            
-        selected_mesh = get_armature_mesh(selected_armature)
-        
+
+        selected_mesh: bpy.types.Object = get_armature_mesh(selected_armature)
+
         shape_keys = selected_mesh.data.shape_keys
+        original_shape_key_lock = selected_mesh.show_only_shape_key
         original_mode = bpy.context.active_object.mode
+        muted_constraints = []
         try:
-            bpy.ops.object.mode_set(mode='OBJECT')
-            armature_modifier: bpy.types.ArmatureModifier = first(selected_mesh.modifiers, lambda mod: mod.type == "ARMATURE")
+            bpy.ops.object.mode_set(mode="OBJECT")
+            armature_modifier: bpy.types.ArmatureModifier = first(
+                selected_mesh.modifiers, lambda mod: mod.type == "ARMATURE"
+            )
+
+            # Turn off shape key lock if it's on otherwise shape keys fail to
+            # import.
+            selected_mesh.show_only_shape_key = False
+
+            # Temporarily mutate all bone constraints since pose assets
+            # are bone based and we don't want constraints to influence
+            # the final pose.
+            muted_constraints = disable_constraints(selected_armature)
+
+            # Swap parents where applicable
+            bone_swap_orig_parents(selected_armature)
 
             if not shape_keys:
                 # Create Basis shape key
                 selected_mesh.shape_key_add(name="Basis", from_mix=False)
 
-            root_bone_name = 'neck_01'
-            root_bone = get_case_insensitive(selected_armature.pose.bones, root_bone_name)
+            root_bone_name = "neck_01"
+            root_bone = get_case_insensitive(
+                selected_armature.pose.bones, root_bone_name
+            )
             if not root_bone:
-                Log.warn(f"{selected_mesh.name}: Failed to find root bone "
-                         f"'{root_bone_name}' in '{selected_armature.name}', all "
-                         "bones will be considered during import of "
-                         "PoseData")
+                Log.warn(
+                    f"{selected_mesh.name}: Failed to find root bone "
+                    f"'{root_bone_name}' in '{selected_armature.name}', all "
+                    "bones will be considered during import of "
+                    "PoseData"
+                )
 
             loc_scale = self.scale
+            pose_names = []
             for pose in pose_data:
-                # If there are no influences, don't bother
-                if not (influences := pose.get('Keys')):
+                if not (pose_name := pose.get("Name")):
+                    Log.warn(
+                        f"{selected_mesh.name}: skipping pose data "
+                        f"with no pose name:\n{pose}"
+                    )
                     continue
+                pose_names.append(pose_name)
 
-                if not (pose_name := pose.get('Name')):
-                    Log.warn(f"{selected_mesh.name}: skipping pose data "
-                             f"with no pose name: {pose}")
+                # If there are no influences, don't bother
+                if not (influences := pose.get("Keys")):
                     continue
 
                 # Enter pose mode
                 bpy.context.view_layer.objects.active = selected_armature
-                bpy.ops.object.mode_set(mode='POSE')
+                bpy.ops.object.mode_set(mode="POSE")
 
                 # Reset all transforms to default
-                bpy.ops.pose.select_all(action='SELECT')
+                bpy.ops.pose.select_all(action="SELECT")
                 bpy.ops.pose.transforms_clear()
-                bpy.ops.pose.select_all(action='DESELECT')
+                bpy.ops.pose.select_all(action="DESELECT")
 
                 # Move bones accordingly
                 contributed = False
                 for bone in influences:
-                    if not (bone_name := bone.get('Name')):
-                        Log.warn(f"{selected_mesh.name} - {pose_name}: "
-                                 f"empty bone name for pose '{pose}'")
+                    if not (bone_name := bone.get("Name")):
+                        Log.warn(
+                            f"{selected_mesh.name} - {pose_name}: "
+                            f"empty bone name for pose:\n{pose}"
+                        )
                         continue
 
-                    pose_bone: bpy.types.PoseBone = get_case_insensitive(selected_armature.pose.bones, bone_name)
+                    pose_bone: bpy.types.PoseBone = get_case_insensitive(
+                        selected_armature.pose.bones, bone_name
+                    )
                     if not pose_bone:
                         # For cases where pose data tries to move a non-existent bone
                         # i.e. Poseidon has no 'Tongue' but it's in the pose asset
-                        if part_type is EFortCustomPartType.HEAD:
+                        if not part_type or part_type is EFortCustomPartType.HEAD:
                             # There are likely many missing bones in non-Head parts, but we
                             # process as many as we can.
-                            Log.warn(f"{selected_mesh.name} - {pose_name}: "
-                                     f"'{bone_name}' influence skipped "
-                                     "since it was not found in "
-                                     f"'{selected_armature.name}'")
+                            Log.warn(
+                                f"{selected_mesh.name} - {pose_name}: "
+                                f"'{bone_name}' influence skipped "
+                                "since it was not found in "
+                                f"'{selected_armature.name}'"
+                            )
                         continue
 
                     if root_bone and not bone_has_parent(pose_bone, root_bone):
-                        Log.warn(f"{selected_mesh.name} - {pose_name}: "
-                                 f"skipped '{pose_bone.name}' since it does "
-                                 f"not have '{root_bone.name}' as a parent")
+                        Log.warn(
+                            f"{selected_mesh.name} - {pose_name}: "
+                            f"skipped '{pose_bone.name}' since it does "
+                            f"not have '{root_bone.name}' as a parent"
+                        )
                         continue
 
                     # Verify that the current bone and all of its children
                     # have at least one vertex group associated with it
-                    if not bone_hierarchy_has_vertex_groups(pose_bone, selected_mesh.vertex_groups):
+                    if not bone_hierarchy_has_vertex_groups(
+                        pose_bone, selected_mesh.vertex_groups
+                    ):
                         continue
 
                     # Reset bone to identity
                     pose_bone.matrix_basis.identity()
 
-                    rotation = bone.get('Rotation')
-                    if not rotation.get('IsNormalized'):
-                        Log.warn(f"rotation not normalized for {bone_name} in pose {pose_name}")
+                    rotation = bone.get("Rotation")
+                    if not rotation.get("IsNormalized"):
+                        Log.warn(
+                            f"{selected_mesh.name} - {pose_name}: "
+                            f"rotation not normalized for '{bone_name}' in "
+                            "pose"
+                        )
 
                     edit_bone = pose_bone.bone
-                    post_quat = Quaternion(post_quat) if (post_quat := edit_bone.get("post_quat")) else Quaternion()
+                    post_quat = (
+                        Quaternion(post_quat)
+                        if (post_quat := edit_bone.get("post_quat"))
+                        else Quaternion()
+                    )
 
                     q = post_quat.copy()
                     q.rotate(make_quat(rotation))
                     quat = post_quat.copy()
                     quat.rotate(q.conjugated())
-                    pose_bone.rotation_quaternion = quat.conjugated() @ pose_bone.rotation_quaternion
+                    pose_bone.rotation_quaternion = (
+                        quat.conjugated() @ pose_bone.rotation_quaternion
+                    )
 
-                    loc = (make_vector(bone.get('Location'), unreal_coords_correction=True))
+                    loc = make_vector(
+                        bone.get("Location"), unreal_coords_correction=True
+                    )
                     loc.rotate(post_quat.conjugated())
 
                     pose_bone.location = pose_bone.location + loc * loc_scale
-                    pose_bone.scale = (Vector((1, 1, 1)) + make_vector(bone.get('Scale')))
+                    pose_bone.scale = Vector((1, 1, 1)) + make_vector(bone.get("Scale"))
 
                     pose_bone.rotation_quaternion.normalize()
                     contributed = True
@@ -1440,23 +1371,121 @@ class ImportContext:
                     continue
 
                 # Create blendshape from armature
-                bpy.ops.object.mode_set(mode='OBJECT')
+                bpy.ops.object.mode_set(mode="OBJECT")
                 bpy.context.view_layer.objects.active = selected_mesh
                 selected_mesh.select_set(True)
-                bpy.ops.object.modifier_apply_as_shapekey(keep_modifier=True,
-                                                          modifier=armature_modifier.name)
+                bpy.ops.object.modifier_apply_as_shapekey(
+                    keep_modifier=True, modifier=armature_modifier.name
+                )
 
                 # Use name from pose data
                 selected_mesh.data.shape_keys.key_blocks[-1].name = pose_name
+
+            if not tracks:
+                return
+
+            bpy.ops.object.mode_set(mode="OBJECT")
+            bpy.context.view_layer.objects.active = selected_mesh
+            selected_mesh.select_set(True)
+
+            # Now that base blendshapes are imported, cycle through all
+            # PoseData again to create blendshapes based on CurveData.
+            for pose in pose_data:
+                if not (curves := pose.get("CurveData")):
+                    continue
+
+                if not (pose_name := pose.get("Name")):
+                    Log.warn(
+                        f"{selected_mesh.name} - {pose_name}: skipping pose "
+                        f"data from curve data with no pose name:\n{pose}"
+                    )
+                    continue
+
+                # Not sure what it means when there's curve data on a pose
+                # also containing bone transforms. So if there's an existing
+                # shape key, just prepend curves_ to distinguish it.
+                # Also, if it exists in the original set of shape keys but it
+                # failed to import for some reason (i.e. missing bone), also
+                # distinguish that name to prevent confusion since the name
+                # of that key may not do what the user expects
+                # (i.e. tongue_up_pose on Fish Thicc created from CurveData).
+                # If we import outside the context of a full character import
+                # (i.e. part_type is None), then only prepend curves_ for
+                # existing shape keys.
+                if pose_name in selected_mesh.data.shape_keys.key_blocks or \
+                   (part_type is EFortCustomPartType.HEAD and pose_name in pose_names):
+                    pose_name = f"curves_{pose_name}"
+
+                # Verify length of CurveData matches that of tracks
+                if len(curves) != len(tracks):
+                    Log.warn(
+                        f"{selected_mesh.name} - {pose_name}: skipped since "
+                        "length of curve data for pose does not match the "
+                        "length of Tracks array"
+                    )
+                    continue
+
+                # If all curve values are basically 0, skip
+                if all(curves, lambda curve_value: abs(curve_value) < 0.00001):
+                    continue
+
+                contributed = False
+                for track_idx, curve_value in enumerate(curves):
+                    # Sometimes curve_value is a very small number (1.7881586e-06).
+                    # Probably best to just normalize it to 0
+                    if abs(curve_value) < 0.00001:
+                        curve_value = 0.0
+
+                    # Even if the curve_value is zero, let it be set anyway
+                    # since this is essentially a free reset to zero for the
+                    # relevant shape keys.
+                    shape_key_name = tracks[track_idx]
+                    if shape_key := selected_mesh.data.shape_keys.key_blocks.get(
+                        shape_key_name
+                    ):
+                        # Influence above / below 1.0 is possible with curve data
+                        if curve_value < shape_key.slider_min:
+                            shape_key.slider_min = curve_value - 1.0
+                        if curve_value > shape_key.slider_max:
+                            shape_key.slider_max = curve_value + 1.0
+                        shape_key.value = curve_value
+                        contributed = True
+                    else:
+                        if not part_type or part_type is EFortCustomPartType.HEAD:
+                            Log.warn(
+                                f"{selected_mesh.name} - {pose_name}: did not "
+                                "apply influence to missing shape key: "
+                                f"'{shape_key_name}'"
+                            )
+
+                # Do not create shape keys if nothing changed
+                if not contributed:
+                    continue
+
+                selected_mesh.shape_key_add(name=pose_name, from_mix=True)
+
+            # Set all shape keys in the track back to 0
+            for shape_key_name in tracks:
+                if shape_key := selected_mesh.data.shape_keys.key_blocks.get(
+                    shape_key_name
+                ):
+                    shape_key.slider_min = 0.0
+                    shape_key.slider_max = 1.0
+                    shape_key.value = 0.0
         except Exception as e:
-            Log.error("Failed to import PoseAsset data from "
-                      f"{selected_mesh.name}: {e}")
+            Log.error(f"Failed to import PoseAsset data from {selected_mesh.name}: {e}")
         finally:
             # Final reset before re-entering regular import mode.
             bpy.context.view_layer.objects.active = selected_armature
-            bpy.ops.object.mode_set(mode='POSE')
-            bpy.ops.pose.select_all(action='SELECT')
+            bpy.ops.object.mode_set(mode="POSE")
+            bpy.ops.pose.select_all(action="SELECT")
             bpy.ops.pose.transforms_clear()
-            bpy.ops.pose.select_all(action='DESELECT')
+            bpy.ops.pose.select_all(action="DESELECT")
+
+            bone_swap_orig_parents(selected_armature)
+            for constraint in muted_constraints:
+                constraint.mute = False
+
+            selected_mesh.show_only_shape_key = original_shape_key_lock
             bpy.ops.object.mode_set(mode=original_mode)
             bpy.context.view_layer.objects.active = original_selected_object

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/tasty.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/tasty.py
@@ -253,7 +253,7 @@ def create_tasty_rig(context, target_skeleton, options: TastyRigOptions):
         if not (bone := edit_bones.get(name)): continue
         if not (parent_bone := edit_bones.get(parent)): continue
 
-        bone.parent = parent_bone
+        bone_parent(bone, parent_bone)
 
     head_adjustment_bones = [
         ("R_eye_lid_upper_mid", Lazy(lambda: edit_bones["R_eye"].head)),
@@ -266,7 +266,7 @@ def create_tasty_rig(context, target_skeleton, options: TastyRigOptions):
         if not (bone := edit_bones.get(bone_name)): continue
         if not (position := lazy.value()): continue
 
-        bone.head = position
+        bone_head(bone, position)
 
     tail_adjustment_bones = [
         ("lowerarm_r", Lazy(lambda: edit_bones["hand_r"].head)),
@@ -281,8 +281,8 @@ def create_tasty_rig(context, target_skeleton, options: TastyRigOptions):
     for bone_name, lazy in tail_adjustment_bones:
         if not (bone := edit_bones.get(bone_name)): continue
         if not (position := lazy.value()): continue
-    
-        bone.tail = position
+
+        bone_tail(bone, position)
 
     roll_adjustment_bones = [
         ("C_jaw", 0),
@@ -291,7 +291,7 @@ def create_tasty_rig(context, target_skeleton, options: TastyRigOptions):
     for name, roll in roll_adjustment_bones:
         if not (bone := edit_bones.get(name)): continue
 
-        bone.roll = roll
+        bone_roll(bone, roll)
 
     transform_adjustment_bones = [
         ("ik_finger_pole_thumb_r", Vector((0.05, 0.0, 0.0))),
@@ -325,7 +325,7 @@ def create_tasty_rig(context, target_skeleton, options: TastyRigOptions):
         bone.matrix @= Matrix.Translation(transform)
 
     if (lower_lip_bone := edit_bones.get("FACIAL_C_LowerLipRotation")) and (jaw_bone := edit_bones.get("FACIAL_C_Jaw")):
-        lower_lip_bone.parent = jaw_bone
+        bone_parent(lower_lip_bone, jaw_bone)
 
     # pose bone modifications
     bpy.ops.object.mode_set(mode='POSE')

--- a/FortnitePorting/Export/ExportContext.cs
+++ b/FortnitePorting/Export/ExportContext.cs
@@ -190,12 +190,16 @@ public class ExportContext
         /* Assert number of tracks == number of bones for given skeleton */
         var poseTracks = poseContainer.Tracks;
 
+        /* Propagate CurveTrackNames for CurveData processing. */
+        if (poseContainer.Curves is not null)
+            meta.CurveTrackNames = poseContainer.Curves.Select(x => x.CurveName.PlainText).ToArray();
+
         if (poseContainer.TrackPoseInfluenceIndices is not null)
         {
             var poseTrackInfluences = poseContainer.TrackPoseInfluenceIndices;
             if (poseTracks.Length != poseTrackInfluences.Length)
             {
-                Log.Warning($"{poseAsset.Name}: length of Tracks != length of TrackPoseInfluenceIndices");
+                Log.Warning($"{poseAsset.Name}: length of CurveTrackNames != length of TrackPoseInfluenceIndices");
                 return;
             }
 

--- a/FortnitePorting/Export/ExportContext.cs
+++ b/FortnitePorting/Export/ExportContext.cs
@@ -199,7 +199,7 @@ public class ExportContext
             var poseTrackInfluences = poseContainer.TrackPoseInfluenceIndices;
             if (poseTracks.Length != poseTrackInfluences.Length)
             {
-                Log.Warning($"{poseAsset.Name}: length of CurveTrackNames != length of TrackPoseInfluenceIndices");
+                Log.Warning($"{poseAsset.Name}: length of Tracks != length of TrackPoseInfluenceIndices");
                 return;
             }
 

--- a/FortnitePorting/Export/Models/ExportMeta.cs
+++ b/FortnitePorting/Export/Models/ExportMeta.cs
@@ -18,6 +18,7 @@ public class ExportMasterSkeletonMeta : BaseMeta
 public class ExportPoseDataMeta : BaseMeta
 {
     public List<PoseData> PoseData = [];
+    public string[] CurveTrackNames = [];
 }
 
 public class ExportAttachMeta : BaseMeta

--- a/FortnitePorting/Export/Types/PoseAssetExport.cs
+++ b/FortnitePorting/Export/Types/PoseAssetExport.cs
@@ -31,7 +31,8 @@ namespace FortnitePorting.Export.Types;
 public class PoseAssetExport : BaseExport
 {
     public List<PoseData> PoseData = [];
-    
+    public string[] CurveTrackNames = [];
+
     public PoseAssetExport(string name, UObject asset, BaseStyleData[] styles, EExportType exportType, ExportDataMeta metaData) : base(name, asset, styles, exportType, metaData)
     {
         if (asset is not UPoseAsset poseAsset) return;
@@ -45,6 +46,7 @@ public class PoseAssetExport : BaseExport
         Exporter.PoseAsset(poseAsset, meta);
 
         PoseData = meta.PoseData;
+        CurveTrackNames = meta.CurveTrackNames;
     }
     
 }


### PR DESCRIPTION
**Summary**

This PR adds support for shape key generation based on `CurveData` for pose entries in `Poses` using `CurveName`s from `Curves` as the driver for `CurveData` values. The assumption is that each `CurveName` is an existing imported shape key. Therefore, generation of `CurveData` based shape keys occurs after a full import of bone influenced poses. This likely won't map 1:1 in all cases, but the general result for at least cases I care about, like the import of ARKit blendshapes via `FortniteGame/Content/ArtTools/Pose_Asset_Remaps/ARKit_Remap_PoseAsset.uasset`, seems to produce correct results.

Do note that curve-based shape keys imported as part of character import will be prepended with `curves_` as they may be shared with bone-based poses which may be preferred.

When importing via standalone Pose Asset, `curves_` is only prepended if a shape key with the same name already exists on the object. Otherwise, it imports as the name provided in the pose. This makes importing ARKit shapes fairly straight forward.

**Special note about ARKit Blendshapes**
* The mapping I provided will not work with metahuman like skins
* Some of the blendshapes need to be manually split for specific left/right morphs. This is fairly easy to do with Blender and `Vertex -> Blend from Shape` using `Basis` with `Add` off.
* Not all ARKit blendshapes are included (like `tongueOut`)

Other changes include:
* Refactor `import_pose_asset_data` to be usable during both standalone import and character import
* Fixed bug where importing pose asset as shape keys with `Shape Key Lock` resulted in empty shape keys
* Fixed inaccurate imports of pose asset data on armatures with Tasty Rig applied

**Testing**
I did some manual testing primarily with Fish Thicc since his pose asset has Curve Data included, however, I'm not entirely sure what its purpose is.

Tested with Tasty Rig on/off, reorient bones on/off, and merge armatures one/off.
Tested normal import, import of ARKit blendshapes, and a wipe & reimport of Fish Thicc pose asset.

Additional testing is appreciated.