### PR TITLE
Adding Asteria (CH4) map definition, and other minor fixes

### DIFF
--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
@@ -846,11 +846,11 @@ class ImportContext:
             replace_shader_node("FP Bean Costume")
             socket_mappings = bean_head_costume_mappings if meta.get("IsHead") else bean_costume_mappings
 
-        if "M_Eyes_Parent" in base_material_path:
+        if "M_Eyes_Parent" in base_material_path or get_param(scalars, "Eye Cornea IOR") is not None:
             replace_shader_node("FP 3L Eyes")
             socket_mappings = eye_mappings
 
-        if "M_HairParent_2023_Parent" in base_material_path:
+        if "M_HairParent_2023" in base_material_path or get_param(textures, "Hair Mask") is not None:
             replace_shader_node("FP Hair")
             socket_mappings = hair_mappings
 
@@ -873,7 +873,7 @@ class ImportContext:
                 setup_params(socket_mappings, pre_fx_node, False)
 
                 thin_film_node = get_node(shader_node, "Thin Film Texture")
-                if get_param_multiple(switches, ["Use Thin Film", "UseThinFilm"]):
+                if get_param_multiple(switches, ["Use Thin Film", "UseThinFilm"]) or "M_ReconExpert_FNCS_Parent" in base_material_path:
                     if thin_film_node is None:
                         thin_film_node = nodes.new(type="ShaderNodeTexImage")
                         thin_film_node.image = bpy.data.images.get("T_ThinFilm_Spectrum_COLOR")

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
@@ -209,7 +209,7 @@ layer_mappings = MappingCollection(
 
         SlotMapping("Diffuse_Texture_2", alpha_slot="MaskTexture_2"),
         SlotMapping("SpecularMasks_2"),
-        SlotMapping("Norm"),
+        SlotMapping("Normals_Texture_2"),
         SlotMapping("Emissive_Texture_2"),
         SlotMapping("MaskTexture_2"),
         SlotMapping("Background Diffuse 2", alpha_slot="Background Diffuse Alpha 2"),

--- a/FortnitePorting/Export/ExportContext.cs
+++ b/FortnitePorting/Export/ExportContext.cs
@@ -104,8 +104,9 @@ public class ExportContext
 
                     if (additionalData.TryGetValue(out UAnimBlueprintGeneratedClass animBlueprint, "AnimClass"))
                     {
-                        var animBlueprintData = animBlueprint.ClassDefaultObject.Load()!;
-                        if (animBlueprintData.TryGetValue(out FStructFallback poseAssetNode, "AnimGraphNode_PoseBlendNode"))
+                        if (animBlueprint.ClassDefaultObject != null 
+                            && animBlueprint.ClassDefaultObject.TryLoad(out var animBlueprintData) 
+                            && animBlueprintData.TryGetValue(out FStructFallback poseAssetNode, "AnimGraphNode_PoseBlendNode"))
                         {
                             PoseAsset(poseAssetNode.Get<UPoseAsset>("PoseAsset"), meta);
                         }
@@ -681,7 +682,7 @@ public class ExportContext
         objects.AddRangeIfNotNull(ConstructionScript(blueprintGeneratedClass));
         objects.AddRangeIfNotNull(InheritableComponentHandler(blueprintGeneratedClass));
 
-        if (blueprintGeneratedClass.ClassDefaultObject.TryLoad(out var classDefaultObject))
+        if (blueprintGeneratedClass.ClassDefaultObject != null && blueprintGeneratedClass.ClassDefaultObject.TryLoad(out var classDefaultObject))
         {
             objects.AddRangeIfNotNull(Actor(classDefaultObject!, loadTemplate: false));
         }
@@ -821,6 +822,10 @@ public class ExportContext
         {
             exportMesh.OverrideVertexColors = overrideVertexColors.Data;
         }
+
+        exportMesh.Location = meshComponent.RelativeLocation;
+        exportMesh.Rotation = meshComponent.RelativeRotation;
+        exportMesh.Scale = meshComponent.RelativeScale3D;
 
         return exportMesh;
     }
@@ -1049,7 +1054,10 @@ public class ExportContext
             {
                 if (parameterCollection.Textures.Any(x => x.Name.Equals(param.Name))) continue;
                 if (!param.ParameterValue.TryLoad(out UTexture texture)) continue;
-                parameterCollection.Textures.AddUnique(new TextureParameter(param.Name, Export(texture), texture.SRGB, texture.CompressionSettings));
+                var embeddedAsset = materialInstance.Owner != null 
+                                    && texture.Owner != null 
+                                    && materialInstance.Owner.Name.Equals(texture.Owner.Name);
+                parameterCollection.Textures.AddUnique(new TextureParameter(param.Name, Export(texture, embeddedAsset: embeddedAsset), texture.SRGB, texture.CompressionSettings));
             }
 
             foreach (var param in materialInstance.ScalarParameterValues)

--- a/FortnitePorting/ViewModels/MapViewModel.cs
+++ b/FortnitePorting/ViewModels/MapViewModel.cs
@@ -98,6 +98,13 @@ public partial class MapViewModel : ViewModelBase
             "FortniteGame/Plugins/GameFeatures/BlastBerry/Content/MiniMap/T_PB_MiniMap_Mask",
             0.0475f, 0, 384, 305, 12800, true
         ),
+        new(
+            "Asteria",
+            "FortniteGame/Content/Athena/Asteria/Maps/Asteria_Terrain",
+            "FortniteGame/Content/Athena/Apollo/Maps/UI/Apollo_Terrain_Minimap",
+            "FortniteGame/Content/Athena/Apollo/Maps/UI/T_MiniMap_Mask",
+            0.01375f, 132, 140, 90, 12800, true
+        ),
         MapInfo.CreateNonDisplay("Athena", "FortniteGame/Content/Athena/Maps/Athena_Terrain"),
         MapInfo.CreateNonDisplay("Apollo", "FortniteGame/Content/Athena/Apollo/Maps/Apollo_Terrain")
     ];


### PR DESCRIPTION
* Added Asteria map tab definition
* Added transform handling for standalone blueprint exporting
* Added additional conditions for the 3L eye and new hair material handling to account for skins with different parent materials
* Added null checks for pose asset and blueprint ClassDefaultObject loading
* Added proper handling for textures embedded in static mesh assets