### PR TITLE
Fix unhandled exception when importing stuff more than once in the same Blender project

### DIFF
--- a/FortnitePorting.Plugins/Blender/fortnite_porting/utils.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/utils.py
@@ -12,22 +12,18 @@ def ensure_blend_data():
                 data_to.node_groups.append(node_group)
 
         for mat in data_from.materials:
-            found_material = bpy.data.materials.get(mat)
-            if hash(found_material) != hash(mat):
-                if found_material:
-                    bpy.data.materials.remove(mat)
-                data_to.materials.append(mat)
+            if found_material := bpy.data.materials.get(mat):
+                bpy.data.materials.remove(found_material)
+            data_to.materials.append(mat)
 
         for image in data_from.images:
             if not bpy.data.images.get(image):
                 data_to.images.append(image)
 
         for obj in data_from.objects:
-            found_object = bpy.data.objects.get(obj)
-            if hash(found_object) != hash(obj):
-                if found_object:
-                    bpy.data.objects.remove(obj)
-                data_to.objects.append(obj)
+            if found_object := bpy.data.objects.get(obj):
+                bpy.data.objects.remove(found_object)
+            data_to.objects.append(obj)
 
         for font in data_from.fonts:
             if not bpy.data.fonts.get(font):


### PR DESCRIPTION
## Summary
If existing materials or objects are attempted to be removed from the Blender project coming from `fortnite_porting_data.blend`, then the following error is raised:
```
[FNPORTING] An unhandled error occurred:
TypeError: BlendDataMaterials.remove(): error with argument 1, "material" -  Function.material expected a Material type, not str
```

This can be reproduced by exporting the same character twice in a fresh Blender project.

This happens because `data_from` entries are populated with strings which are to be used to stage what you want to import by appending to `data_to`. If we wanted to perform some kind of comparison with the loaded data, we'd want to access `data_to` outside of the context after the load has finished. See https://docs.blender.org/api/4.2/bpy.types.BlendDataLibraries.html#bpy.types.BlendDataLibraries.load for more information.

I'm keeping things simple in this PR by just always removing the material/object if it's found by name. It may be possible to test for equality by inspecting material nodes or object properties and then removing the newly imported data if it's found to be the same.