### PR TITLE
Adding UV2 composite material support

### DIFF
--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
@@ -627,7 +627,10 @@ class ImportContext:
                     return
 
                 value = mappings.value_func(value) if mappings.value_func else value
-                target_node.inputs[mappings.slot].default_value = (value["R"], value["G"], value["B"], 1.0)
+                if isinstance(target_node.inputs[mappings.slot], bpy.types.NodeSocketColor):
+                    target_node.inputs[mappings.slot].default_value = (value["R"], value["G"], value["B"], 1.0)
+                else:
+                    target_node.inputs[mappings.slot].default_value = (value["R"], value["G"], value["B"])
                 if mappings.alpha_slot:
                     target_node.inputs[mappings.alpha_slot].default_value = value["A"]
                 if mappings.switch_slot:
@@ -706,6 +709,17 @@ class ImportContext:
 
             for switch in switches:
                 switch_param(switch, mappings, target_node, add_unused_params)
+
+        def move_texture_node(target_node, slot_name):
+            if texture_node := get_node(shader_node, slot_name):
+                x, y = get_socket_pos(target_node, target_node.inputs.find(slot_name))
+                texture_node.location = x - 300, y
+                links.new(texture_node.outputs[0], target_node.inputs[slot_name])
+                links.new(target_node.outputs[slot_name], shader_node.inputs[slot_name])
+
+        def connect_texture_uvs(target_node, slot_name, uv_output):
+            if texture_node := get_node(target_node, slot_name):
+                links.new(uv_output, texture_node.inputs[0])
 
         # decide which material type and mappings to use
         socket_mappings = default_mappings
@@ -983,10 +997,7 @@ class ImportContext:
                             pre_superhero_node = nodes.new(type="ShaderNodeGroup")
                             pre_superhero_node.node_tree = bpy.data.node_groups.get("FPv3 Pre Superhero")
                             pre_superhero_node.location = -1150, -560
-                            pre_superhero_node.inputs["StickerPosition"].default_value = get_vector_param(vectors, "StickerPosition")
-                            pre_superhero_node.inputs["StickerScale"].default_value = get_vector_param(vectors, "StickerScale")
-                            pre_superhero_node.inputs["BackStickerPosition"].default_value = get_vector_param(vectors, "BackStickerPosition")
-                            pre_superhero_node.inputs["BackStickerScale"].default_value = get_vector_param(vectors, "BackStickerScale")
+                            setup_params(superhero_mappings, pre_superhero_node, False)
 
                             links.new(pre_superhero_node.outputs["StickerUV"], sticker_node.inputs[0])
                             links.new(pre_superhero_node.outputs["StickerMask"], superhero_node.inputs["StickerMask"])
@@ -1003,6 +1014,35 @@ class ImportContext:
                     links.new(superhero_node.outputs["Normals"], shader_node.inputs["Normals"])
                     links.new(superhero_node.outputs["SpecularMasks"], shader_node.inputs["SpecularMasks"])
                     links.new(superhero_node.outputs["ClothFuzzChannel"], shader_node.inputs["Cloth Channel"])
+
+                    shader_node.inputs["Background Diffuse Alpha"].default_value = 0.0
+                    links.new(superhero_node.outputs["Diffuse"], shader_node.inputs["Background Diffuse"])
+                    links.new(superhero_node.outputs["Normals"], shader_node.inputs["Normals"])
+                    links.new(superhero_node.outputs["SpecularMasks"], shader_node.inputs["SpecularMasks"])
+                    links.new(superhero_node.outputs["ClothFuzzChannel"], shader_node.inputs["Cloth Channel"])
+
+                if get_param(switches, "UseUV2Composite"):
+                    composite_node = nodes.new(type="ShaderNodeGroup")
+                    composite_node.node_tree = bpy.data.node_groups.get("FPv3 Composite")
+                    composite_node.location = -600, 0
+                    setup_params(composite_mappings, composite_node, False)
+
+                    pre_composite_node = nodes.new(type="ShaderNodeGroup")
+                    pre_composite_node.node_tree = bpy.data.node_groups.get("FPv3 Pre Composite")
+                    pre_composite_node.location = -1150, -225
+                    setup_params(composite_mappings, pre_composite_node, False)
+
+                    connect_texture_uvs(composite_node, "UV2Composite_AlphaTexture", pre_composite_node.outputs[0])
+                    connect_texture_uvs(composite_node, "UV2Composite_Diffuse", pre_composite_node.outputs[1])
+                    connect_texture_uvs(composite_node, "UV2Composite_Normals", pre_composite_node.outputs[1])
+                    connect_texture_uvs(composite_node, "UV2Composite_SRM", pre_composite_node.outputs[1])
+
+                    move_texture_node(composite_node, "Diffuse")
+                    move_texture_node(composite_node, "Normals")
+                    move_texture_node(composite_node, "SpecularMasks")
+
+                    if diffuse_node := get_node(composite_node, "Diffuse"):
+                        nodes.active = diffuse_node
                     
 
             case "FPv3 Glass":
@@ -1170,9 +1210,7 @@ class ImportContext:
                     
                     def import_curve_mapping(curve_mapping):
                         for curve_mapping in curve_mapping:
-                            curve_name = curve_mapping.get("Name").lower().replace("ctrl_expressions_", "")
-                            
-                            if target_block := first(key_blocks, lambda block: block.name.lower() == curve_name):
+                            if target_block := first(key_blocks, lambda block: block.name.lower() in curve_mapping.get("Name").lower()):
                                 for frame in range(section_length_frames):
                                     value_stack = []
 
@@ -1292,9 +1330,7 @@ class ImportContext:
                     
                     if (is_skeleton_legacy and is_anim_legacy) or (is_anim_metahuman and is_anim_metahuman):
                         for curve in anim_data.curves:
-                            curve_name = curve.name.lower().replace("ctrl_expressions_", "")
-
-                            if target_block := first(key_blocks, lambda block: block.name.lower() == curve_name):
+                            if target_block := first(key_blocks, lambda block: block.name.lower() in curve.name.lower()):
                                 for key in curve.keys:
                                     target_block.value = key.value
                                     target_block.keyframe_insert(data_path="value", frame=key.frame)

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
@@ -670,11 +670,37 @@ superhero_mappings = MappingCollection(
         SlotMapping("PrimaryMaterial"),
         SlotMapping("SecondaryMaterial"),
         SlotMapping("AccessoryMaterial"),
-        SlotMapping("Sticker MSRE")
+        SlotMapping("Sticker MSRE"),
+        SlotMapping("StickerPosition"),
+        SlotMapping("StickerScale"),
+        SlotMapping("BackStickerPosition"),
+        SlotMapping("BackStickerScale"),
     ],
     scalars=[
         SlotMapping("PrimaryCloth"),
         SlotMapping("SecondaryCloth"),
         SlotMapping("ElasticStickerMult")
+    ]
+)
+
+composite_mappings = MappingCollection(
+    textures=[
+        SlotMapping("UV2Composite_AlphaTexture"),
+        SlotMapping("UV2Composite_Diffuse", alpha_slot="UV2Composite_Diffuse Alpha"),
+        SlotMapping("UV2Composite_Normals"),
+        SlotMapping("UV2Composite_SRM"),
+    ],
+    scalars=[
+        SlotMapping("UV2Composite_AlphaStrength"),
+    ],
+    vectors=[
+        SlotMapping("UV2Composite_AlphaChannel"),
+    ],
+    switches=[
+        SlotMapping("UV2Composite_AlphaTextureUseUV1"),
+        SlotMapping("UseDiffuseAlphaChannel"),
+        SlotMapping("UseUV2Diffuse"),
+        SlotMapping("UseUV2Normals"),
+        SlotMapping("UseUV2SRM"),
     ]
 )


### PR DESCRIPTION
Adds support for materials that use the "UV2 Composite" logic, like Stix, Courtside Axo, Power Punk, and Ziggy.  I also made the shape key name change to add support for head meshes with metahuman DNA shape keys applied

![image](https://github.com/user-attachments/assets/4d57e41a-b215-438a-a0bc-58b7c2fda5db)
