### PR TITLE
Adding FPv3 Detail material support and fixed like-name face curve matching

### DIFF
--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
@@ -1286,8 +1286,7 @@ class ImportContext:
 
                                             case EOpElementType.NAME:
                                                 sub_curve_name = str(element_value)
-                                                target_curve = best(anim_data.curves, lambda curve: curve.name.lower(), sub_curve_name.lower())
-                                                if target_curve:
+                                                if target_curve := best(anim_data.curves, lambda curve: curve.name.lower(), sub_curve_name.lower()):
                                                     target_value = interpolate_keyframes(target_curve.keys, frame, fps=anim_data.metadata.frames_per_second)
                                                     value_stack.append(target_value)
                                                 else:

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
@@ -1286,7 +1286,7 @@ class ImportContext:
 
                                             case EOpElementType.NAME:
                                                 sub_curve_name = str(element_value)
-                                                target_curve = first(anim_data.curves, lambda curve: curve.name.lower().replace("ctrl_expressions_", "") == sub_curve_name.lower())
+                                                target_curve = best(anim_data.curves, lambda curve: curve.name.lower(), sub_curve_name.lower())
                                                 if target_curve:
                                                     target_value = interpolate_keyframes(target_curve.keys, frame, fps=anim_data.metadata.frames_per_second)
                                                     value_stack.append(target_value)

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
@@ -1059,6 +1059,28 @@ class ImportContext:
 
                     if diffuse_node := get_node(composite_node, "Diffuse"):
                         nodes.active = diffuse_node
+
+                if "M_Detail_Texturing_Parent_2025" in base_material_path:
+                    detail_node = nodes.new(type="ShaderNodeGroup")
+                    detail_node.node_tree = bpy.data.node_groups.get("FPv3 Detail")
+                    detail_node.location = -600, 0
+                    setup_params(detail_mappings, detail_node, False)
+
+                    pre_detail_node = nodes.new(type="ShaderNodeGroup")
+                    pre_detail_node.node_tree = bpy.data.node_groups.get("FPv3 Pre Detail")
+                    pre_detail_node.location = -1150, -350
+                    setup_params(detail_mappings, pre_detail_node, False)
+
+                    connect_texture_uvs(detail_node, "Detail Diffuse", pre_detail_node.outputs[0])
+                    connect_texture_uvs(detail_node, "Detail Normal", pre_detail_node.outputs[0])
+                    connect_texture_uvs(detail_node, "Detail SRM", pre_detail_node.outputs[0])
+
+                    move_texture_node(detail_node, "Diffuse")
+                    move_texture_node(detail_node, "Normals")
+                    move_texture_node(detail_node, "SpecularMasks")
+
+                    if diffuse_node := get_node(detail_node, "Diffuse"):
+                        nodes.active = diffuse_node
                     
 
             case "FPv3 Glass":
@@ -1226,7 +1248,7 @@ class ImportContext:
                     
                     def import_curve_mapping(curve_mapping):
                         for curve_mapping in curve_mapping:
-                            if target_block := first(key_blocks, lambda block: block.name.lower() in curve_mapping.get("Name").lower()):
+                            if (target_block := first(key_blocks, lambda block: block.name.lower() == curve_mapping.get("Name").lower())) or (target_block := first(key_blocks, lambda block: block.name.lower() in curve_mapping.get("Name").lower())):
                                 for frame in range(section_length_frames):
                                     value_stack = []
 
@@ -1346,7 +1368,7 @@ class ImportContext:
                     
                     if (is_skeleton_legacy and is_anim_legacy) or (is_anim_metahuman and is_anim_metahuman):
                         for curve in anim_data.curves:
-                            if target_block := first(key_blocks, lambda block: block.name.lower() in curve.name.lower()):
+                            if (target_block := first(key_blocks, lambda block: block.name.lower() == curve.name.lower())) or (target_block := first(key_blocks, lambda block: block.name.lower() in curve.name.lower())):
                                 for key in curve.keys:
                                     target_block.value = key.value
                                     target_block.keyframe_insert(data_path="value", frame=key.frame)

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/import_context.py
@@ -1248,7 +1248,7 @@ class ImportContext:
                     
                     def import_curve_mapping(curve_mapping):
                         for curve_mapping in curve_mapping:
-                            if (target_block := first(key_blocks, lambda block: block.name.lower() == curve_mapping.get("Name").lower())) or (target_block := first(key_blocks, lambda block: block.name.lower() in curve_mapping.get("Name").lower())):
+                            if target_block := best(key_blocks, lambda block: block.name.lower(), curve_mapping.get("Name").lower()):
                                 for frame in range(section_length_frames):
                                     value_stack = []
 
@@ -1368,7 +1368,7 @@ class ImportContext:
                     
                     if (is_skeleton_legacy and is_anim_legacy) or (is_anim_metahuman and is_anim_metahuman):
                         for curve in anim_data.curves:
-                            if (target_block := first(key_blocks, lambda block: block.name.lower() == curve.name.lower())) or (target_block := first(key_blocks, lambda block: block.name.lower() in curve.name.lower())):
+                            if target_block := best(key_blocks, lambda block: block.name.lower(), curve.name.lower()):
                                 for key in curve.keys:
                                     target_block.value = key.value
                                     target_block.keyframe_insert(data_path="value", frame=key.frame)

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
@@ -707,3 +707,30 @@ composite_mappings = MappingCollection(
         SlotMapping("UseUV2SRM"),
     ]
 )
+
+detail_mappings = MappingCollection(
+    textures=[
+        SlotMapping("TechArtMask"),
+        SlotMapping("Detail Diffuse"),
+        SlotMapping("Detail Normal"),
+        SlotMapping("Detail SRM"),
+    ],
+    scalars=[
+        SlotMapping("Detail Texture - Tiling"),
+        SlotMapping("Detail Texture - UV Rotation"),
+        SlotMapping("Detail Diffuse - Strength"),
+        SlotMapping("Detail Normal - Flatten Normal"),
+        SlotMapping("Detail Specular - Strength"),
+        SlotMapping("Detail Roughness - Strength"),
+        SlotMapping("Detail Metallic - Strength"),
+    ],
+    vectors=[
+        SlotMapping("Detail Texture - Channel Mask"),
+    ],
+    switches=[
+        SlotMapping("Detail Texture - Use UV2"),
+        SlotMapping("Use Detail Diffuse?"),
+        SlotMapping("Use Detail Normal?"),
+        SlotMapping("Use Detail SRM?"),
+    ]
+)

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/mappings.py
@@ -73,6 +73,7 @@ default_mappings = MappingCollection(
         SlotMapping("PM_Emissive", "Emission"),
         SlotMapping("Visor_Emissive", "Emission"),
         SlotMapping("EmissiveDistanceField"),
+        SlotMapping("DF Texture", "EmissiveDistanceField"),
         SlotMapping("Visor_EmissiveDistanceField", "EmissiveDistanceField"),
         SlotMapping("Visor_EmissiveDistanceFieldStyle2", "EmissiveDistanceField"),
 

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/utils.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/utils.py
@@ -38,6 +38,20 @@ def first(target, expr, default=None):
 
     return next(filtered, default)
 
+def best(target, expr, goal, default=None):
+    if not target:
+        return None
+
+    for item in target:
+        if expr(item) == goal:
+            return item
+
+    for item in target:
+        if expr(item) in goal:
+            return item
+
+    return default
+
 
 def where(target, expr):
     if not target:

--- a/FortnitePorting.Plugins/Blender/io_scene_ueformat/importer/logic.py
+++ b/FortnitePorting.Plugins/Blender/io_scene_ueformat/importer/logic.py
@@ -583,7 +583,7 @@ class UEFormatImport:
                     
                 for curve in data.curves:
                     
-                    if not (shape_key := first(key_blocks, lambda block: block.name.lower() in curve.name.lower())):
+                    if not ((shape_key := first(key_blocks, lambda block: block.name.lower() == curve.name.lower())) or (shape_key := first(key_blocks, lambda block: block.name.lower() in curve.name.lower()))):
                         continue
                         
                     for key in curve.keys:

--- a/FortnitePorting.Plugins/Blender/io_scene_ueformat/importer/logic.py
+++ b/FortnitePorting.Plugins/Blender/io_scene_ueformat/importer/logic.py
@@ -583,7 +583,7 @@ class UEFormatImport:
                     
                 for curve in data.curves:
                     
-                    if not ((shape_key := first(key_blocks, lambda block: block.name.lower() == curve.name.lower())) or (shape_key := first(key_blocks, lambda block: block.name.lower() in curve.name.lower()))):
+                    if not (shape_key := best(key_blocks, lambda block: block.name.lower(), curve.name.lower())):
                         continue
                         
                     for key in curve.keys:

--- a/FortnitePorting.Plugins/Blender/io_scene_ueformat/importer/utils.py
+++ b/FortnitePorting.Plugins/Blender/io_scene_ueformat/importer/utils.py
@@ -18,6 +18,20 @@ def first(target, expr, default=None):
 
     return next(filtered, default)
 
+def best(target, expr, goal, default=None):
+    if not target:
+        return None
+    
+    for item in target:
+        if expr(item) == goal:
+            return item
+    
+    for item in target:
+        if expr(item) in goal:
+            return item
+    
+    return default
+
 def make_axis_vector(vec_in: Vector) -> Vector:
     vec_out = Vector()
     x, y, z = vec_in

--- a/FortnitePorting/ViewModels/MapViewModel.cs
+++ b/FortnitePorting/ViewModels/MapViewModel.cs
@@ -130,6 +130,13 @@ public partial class MapViewModel : ViewModelBase
             "/BlastBerryMapUI/MiniMap/MMap_DasBerry_Mask",
             0.0235f, -20, 210, 153, 12800, true
         ),
+        new(
+            "TimberStake",
+            "/4c3853ea-4fd0-364f-c3f9-dabd19e43a23/TimberStake",
+            "/BlastBerryMapUI/MiniMap/Discovered_TimberStake",
+            "/BlastBerryMapUI/MiniMap/MMap_TimberStake_Mask",
+            0.027f, 40, 15, 175, 12800, false, false
+        ),
         
         // ballistic
         new(


### PR DESCRIPTION
**FPv3 Detail material support**: new node group to support detail masks, such as those used on the new Squid Games guard skins
<img width="1575" height="1127" alt="image" src="https://github.com/user-attachments/assets/77ada664-0e0c-4f91-b3fd-b81be28c3977" />

**Face curve matching fixes**: With the current "contains" check we were doing for the face curves, we'd end up in cases where a similarly-named shape key might be used instead of the correct shape key.  For example, the curve "ctrl_expressions_jawopenextreme" would sometimes match with the "ctrl_expressions_jawopen" shape key